### PR TITLE
feat: implement process verification logic in registry contract

### DIFF
--- a/contracts/registry/Cargo.toml
+++ b/contracts/registry/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "lib"]
 soroban-sdk = "25.1.0"
 
 [dev-dependencies]
+ed25519-dalek = "2.2.0"
 soroban-sdk = { version = "25.1.0", features = ["testutils"] }
 
 [profile.release]

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -1,23 +1,210 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, xdr::ToXdr, BytesN, Env, String,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum VerificationError {
+    NotFound = 1,
+    Unauthorized = 2,
+    InvalidSignature = 3,
+    InvalidAttestation = 4,
+    AlreadyProcessed = 5,
+    InvalidTeeHash = 6,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestState {
+    Pending,
+    Verified,
+    Rejected(String),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerificationRequest {
+    pub id: u64,
+    pub state: RequestState,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    pub provider: BytesN<32>,
+    pub tee_hash: BytesN<32>,
+    pub request_id: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Request(u64),
+    Provider(BytesN<32>),
+    TeeHash(BytesN<32>),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderEventData {
+    pub provider: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TeeHashEventData {
+    pub hash: BytesN<32>,
+}
 
 #[contract]
-pub struct Contract;
+pub struct Registry;
 
-// This is a sample contract. Replace this placeholder with your own contract logic.
-// A corresponding test example is available in `test.rs`.
-//
-// For comprehensive examples, visit <https://github.com/stellar/soroban-examples>.
-// The repository includes use cases for the Stellar ecosystem, such as data storage on
-// the blockchain, token swaps, liquidity pools, and more.
-//
-// Refer to the official documentation:
-// <https://developers.stellar.org/docs/build/smart-contracts/overview>.
 #[contractimpl]
-impl Contract {
-    pub fn hello(env: Env, to: String) -> Vec<String> {
-        vec![&env, String::from_str(&env, "Hello"), to]
+impl Registry {
+    /// Setup helper: Add a provider
+    pub fn add_provider(env: Env, provider: BytesN<32>) {
+        env.storage().persistent().set(&DataKey::Provider(provider.clone()), &true);
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "registry"),
+                soroban_sdk::Symbol::new(&env, "ProviderAdded"),
+                provider.clone(),
+            ),
+            ProviderEventData {
+                provider: provider.clone(),
+            },
+        );
+    }
+
+    /// Setup helper: Remove a provider
+    pub fn remove_provider(env: Env, provider: BytesN<32>) {
+        env.storage().persistent().remove(&DataKey::Provider(provider.clone()));
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "registry"),
+                soroban_sdk::Symbol::new(&env, "ProviderRemoved"),
+                provider.clone(),
+            ),
+            ProviderEventData {
+                provider: provider.clone(),
+            },
+        );
+    }
+
+    /// Setup helper: Add a TEE hash
+    pub fn add_tee_hash(env: Env, hash: BytesN<32>) {
+        env.storage().persistent().set(&DataKey::TeeHash(hash.clone()), &true);
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "registry"),
+                soroban_sdk::Symbol::new(&env, "TeeHashAdded"),
+                hash.clone(),
+            ),
+            TeeHashEventData {
+                hash: hash.clone(),
+            },
+        );
+    }
+
+    /// Setup helper: Remove a TEE hash
+    pub fn remove_tee_hash(env: Env, hash: BytesN<32>) {
+        env.storage().persistent().remove(&DataKey::TeeHash(hash.clone()));
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "registry"),
+                soroban_sdk::Symbol::new(&env, "TeeHashRemoved"),
+                hash.clone(),
+            ),
+            TeeHashEventData {
+                hash: hash.clone(),
+            },
+        );
+    }
+
+    /// Setup helper: Create a pending request
+    pub fn create_request(env: Env, id: u64) {
+        let req = VerificationRequest {
+            id,
+            state: RequestState::Pending,
+        };
+        env.storage().persistent().set(&DataKey::Request(id), &req);
+    }
+
+    /// Get a request
+    pub fn get_request(env: Env, id: u64) -> Option<VerificationRequest> {
+        env.storage().persistent().get(&DataKey::Request(id))
+    }
+
+    /// Core processing logic
+    pub fn process_verification(
+        env: Env,
+        request_id: u64,
+        attestation: Attestation,
+        signature: BytesN<64>,
+    ) -> Result<RequestState, VerificationError> {
+        // 1. Retrieve the verification request by request_id
+        let mut req: VerificationRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Request(request_id))
+            .ok_or(VerificationError::NotFound)?;
+
+        // 2. Verify the request is in a processable state
+        if req.state != RequestState::Pending {
+            return Err(VerificationError::AlreadyProcessed);
+        }
+
+        // 3. Validate the signature ... 
+        let payload = attestation.clone().to_xdr(&env);
+        env.crypto()
+            .ed25519_verify(&attestation.provider, &payload, &signature);
+
+        // 4. Registry check
+        let is_authorized: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Provider(attestation.provider.clone()))
+            .unwrap_or(false);
+
+        if !is_authorized {
+            req.state = RequestState::Rejected(String::from_str(&env, "Unauthorized"));
+            env.storage().persistent().set(&DataKey::Request(request_id), &req);
+            return Ok(req.state);
+        }
+
+        // 4.1 TEE Hash check
+        let is_tee_authorized: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TeeHash(attestation.tee_hash.clone()))
+            .unwrap_or(false);
+
+        if !is_tee_authorized {
+            req.state = RequestState::Rejected(String::from_str(&env, "InvalidTeeHash"));
+            env.storage().persistent().set(&DataKey::Request(request_id), &req);
+            return Ok(req.state);
+        }
+
+        // 5. Attestation validation
+        if attestation.request_id != request_id {
+            req.state = RequestState::Rejected(String::from_str(&env, "InvalidAttestation"));
+            env.storage().persistent().set(&DataKey::Request(request_id), &req);
+            return Ok(req.state);
+        }
+
+        // If all checks pass: update request state to Verified and save
+        req.state = RequestState::Verified;
+        env.storage().persistent().set(&DataKey::Request(request_id), &req);
+
+        Ok(req.state)
     }
 }
 
+#[cfg(test)]
 mod test;

--- a/contracts/registry/src/test.rs
+++ b/contracts/registry/src/test.rs
@@ -1,21 +1,278 @@
 #![cfg(test)]
+extern crate std;
 
 use super::*;
-use soroban_sdk::{vec, Env, String};
+use soroban_sdk::{BytesN, Env};
+use ed25519_dalek::{Signer, SigningKey};
+use soroban_sdk::xdr::ToXdr;
+
+fn create_keypair(env: &Env, seed: u8) -> (SigningKey, BytesN<32>) {
+    let secret = [seed; 32];
+    let signing_key = SigningKey::from_bytes(&secret);
+    let public_key = signing_key.verifying_key();
+    let pk_bytes: [u8; 32] = public_key.to_bytes();
+    (signing_key, BytesN::from_array(env, &pk_bytes))
+}
+
+fn sign_payload(env: &Env, signing_key: &SigningKey, payload: &[u8]) -> BytesN<64> {
+    let signature = signing_key.sign(payload);
+    let sig_bytes: [u8; 64] = signature.to_bytes();
+    BytesN::from_array(env, &sig_bytes)
+}
 
 #[test]
-fn test() {
+fn test_successful_verification() {
     let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
 
-    let words = client.hello(&String::from_str(&env, "Dev"));
-    assert_eq!(
-        words,
-        vec![
-            &env,
-            String::from_str(&env, "Hello"),
-            String::from_str(&env, "Dev"),
-        ]
-    );
+    let (signing_key, pk) = create_keypair(&env, 1);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+
+    // Setup
+    client.add_provider(&pk);
+    client.add_tee_hash(&tee_hash);
+    client.create_request(&1);
+
+    // Create attestation
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: tee_hash.clone(),
+        request_id: 1,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    let signature = sign_payload(&env, &signing_key, payload_slice);
+
+    client.process_verification(&1, &attestation, &signature);
+
+    let req = client.get_request(&1).unwrap();
+    assert_eq!(req.state, RequestState::Verified);
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_signature() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let (_signing_key, pk) = create_keypair(&env, 1);
+    let (_other_key, _other_pk) = create_keypair(&env, 2);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+
+    // Setup
+    client.add_provider(&pk);
+    client.add_tee_hash(&tee_hash);
+    client.create_request(&1);
+
+    // Create attestation
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: tee_hash.clone(),
+        request_id: 1,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    // Sign with WRONG key
+    let signature = sign_payload(&env, &_other_key, payload_slice);
+
+    // This will abort the transaction entirely because ed25519_verify aborts.
+    client.process_verification(&1, &attestation, &signature);
+}
+
+#[test]
+fn test_unauthorized_provider() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let (signing_key, pk) = create_keypair(&env, 1);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+    // DO NOT AUTHORIZE this provider
+
+    client.add_tee_hash(&tee_hash);
+    client.create_request(&1);
+
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: tee_hash.clone(),
+        request_id: 1,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    let signature = sign_payload(&env, &signing_key, payload_slice);
+
+    let result = client.try_process_verification(&1, &attestation, &signature);
+    assert_eq!(result, Ok(Ok(RequestState::Rejected(soroban_sdk::String::from_str(&env, "Unauthorized")))));
+
+    let req = client.get_request(&1).unwrap();
+    assert_eq!(req.state, RequestState::Rejected(soroban_sdk::String::from_str(&env, "Unauthorized")));
+}
+
+#[test]
+fn test_invalid_tee_hash() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let (signing_key, pk) = create_keypair(&env, 1);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+    let unauthorized_tee_hash = BytesN::from_array(&env, &[88; 32]);
+
+    client.add_provider(&pk);
+    // DO NOT AUTHORIZE authorized_tee_hash
+    client.create_request(&1);
+
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: unauthorized_tee_hash.clone(),
+        request_id: 1,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    let signature = sign_payload(&env, &signing_key, payload_slice);
+
+    let result = client.try_process_verification(&1, &attestation, &signature);
+    assert_eq!(result, Ok(Ok(RequestState::Rejected(soroban_sdk::String::from_str(&env, "InvalidTeeHash")))));
+
+    let req = client.get_request(&1).unwrap();
+    assert_eq!(req.state, RequestState::Rejected(soroban_sdk::String::from_str(&env, "InvalidTeeHash")));
+}
+
+#[test]
+fn test_invalid_attestation() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let (signing_key, pk) = create_keypair(&env, 1);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+
+    client.add_provider(&pk);
+    client.add_tee_hash(&tee_hash);
+    client.create_request(&1); // id is 1
+
+    // Attestation claims id is 2
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: tee_hash.clone(),
+        request_id: 2,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    let signature = sign_payload(&env, &signing_key, payload_slice);
+
+    // Call with id 1, but attestation has id 2
+    let result = client.try_process_verification(&1, &attestation, &signature);
+    assert_eq!(result, Ok(Ok(RequestState::Rejected(soroban_sdk::String::from_str(&env, "InvalidAttestation")))));
+
+    let req = client.get_request(&1).unwrap();
+    assert_eq!(req.state, RequestState::Rejected(soroban_sdk::String::from_str(&env, "InvalidAttestation")));
+}
+
+#[test]
+fn test_not_found() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let (signing_key, pk) = create_keypair(&env, 1);
+    let tee_hash = BytesN::from_array(&env, &[77; 32]);
+
+    // No request is created
+
+    let attestation = Attestation {
+        provider: pk.clone(),
+        tee_hash: tee_hash.clone(),
+        request_id: 1,
+    };
+
+    let payload = attestation.clone().to_xdr(&env);
+    let mut payload_buf = [0u8; 2048];
+    let payload_slice = {
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut payload_buf[..len]);
+        &payload_buf[..len]
+    };
+    
+    let signature = sign_payload(&env, &signing_key, payload_slice);
+
+    let result = client.try_process_verification(&1, &attestation, &signature);
+    assert_eq!(result, Err(Ok(VerificationError::NotFound)));
+}
+
+#[test]
+fn test_registry_events() {
+    let env = Env::default();
+    let contract_id = env.register(Registry, ());
+    let client = RegistryClient::new(&env, &contract_id);
+
+    let pk = BytesN::from_array(&env, &[1; 32]);
+    let hash = BytesN::from_array(&env, &[2; 32]);
+
+    // Test ProviderAdded
+    client.add_provider(&pk);
+    let events = soroban_sdk::testutils::Events::all(&env.events());
+    let events_str = std::format!("{:#?}", events);
+    assert!(events_str.contains("ProviderAdded"));
+    assert!(events_str.contains("registry"));
+    assert!(events_str.contains("provider"));
+
+    // Test ProviderRemoved
+    client.remove_provider(&pk);
+    let events = soroban_sdk::testutils::Events::all(&env.events());
+    let events_str = std::format!("{:#?}", events);
+    assert!(events_str.contains("ProviderRemoved"));
+    assert!(events_str.contains("registry"));
+
+    // Test TeeHashAdded
+    client.add_tee_hash(&hash);
+    let events = soroban_sdk::testutils::Events::all(&env.events());
+    let events_str = std::format!("{:#?}", events);
+    assert!(events_str.contains("TeeHashAdded"));
+    assert!(events_str.contains("registry"));
+    assert!(events_str.contains("hash"));
+
+    // Test TeeHashRemoved
+    client.remove_tee_hash(&hash);
+    let events = soroban_sdk::testutils::Events::all(&env.events());
+    let events_str = std::format!("{:#?}", events);
+    assert!(events_str.contains("TeeHashRemoved"));
+    assert!(events_str.contains("registry"));
 }

--- a/docs/verification_pipeline.md
+++ b/docs/verification_pipeline.md
@@ -1,0 +1,35 @@
+# Verification Pipeline Documentation
+
+The Verification Pipeline is the core logic of the StellarProof system, now integrated into the Registry contract to ensure all verifications are validated against the authorized registry of providers and TEE environments.
+
+## Workflow Overview
+
+When an off-chain oracle provider processes a verification request, it submits an `Attestation` and a cryptographic `Signature` to the `process_verification` function. The pipeline executes the following steps in strict order to ensure deterministic and atomic transitions:
+
+1. **Request Retrieval**: The contract lookups the `VerificationRequest` using the provided `request_id`.
+2. **State Guard**: Ensures the request is in the `Pending` state. If it is already `Verified` or `Rejected`, the transaction fails with `AlreadyProcessed`.
+3. **Signature Validation**: The `Signature` is verified against the `Attestation` payload using the provider's public key (found in the attestation).
+4. **Registry Check**:
+   - **Provider Authorization**: Validates that the signing provider is currently authorized in the `Provider` registry.
+   - **TEE Hash Authorization**: Validates that the TEE hash reported in the attestation is currently authorized in the `TeeHash` registry.
+5. **Attestation Correspondence**: Ensures the `request_id` within the attestation matches the `request_id` passed to the function.
+6. **State Transition**:
+   - On full success: State is updated to `Verified`.
+   - On any validation failure: State is updated to `Rejected` with a specific reason.
+
+## Failure Modes and Error Variants
+
+The pipeline uses typed errors and state transitions to handle failures gracefully.
+
+| Error | Meaning | State Transition |
+|-------|---------|------------------|
+| `NotFound` | The `request_id` does not exist in storage. | None (Transaction Fails) |
+| `AlreadyProcessed` | The request is already in a final state (`Verified` or `Rejected`). | None (Transaction Fails) |
+| `InvalidSignature` | The cryptographic signature does not match the attestation payload. | `Rejected` (Host Abort via `ed25519_verify`) |
+| `Unauthorized` | The provider is not listed in the authorized registry. | `Rejected("Unauthorized")` |
+| `InvalidTeeHash` | The TEE hash is not in the authorized list. | `Rejected("InvalidTeeHash")` |
+| `InvalidAttestation` | The attestation payload is malformed or doesn't match the request ID. | `Rejected("InvalidAttestation")` |
+
+## Atomic Storage
+
+All state transitions are atomic. If a validation check fails (except for signature validation which aborts), the contract updates the request state to `Rejected` and persists it, ensuring no request is left in a `Pending` state after the pipeline has been invoked.


### PR DESCRIPTION
This PR implements the process_verification function in the **Registry contract** as requested. It includes the state machine transitions, signature validation, and registry checks (Provider and TEE hash). Closes #33.