### PR TITLE
feat: Standardize Registry Events and Admin Gating

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -79,22 +79,17 @@ impl Registry {
     /// Only the admin may call this function.
     /// Emits a `TeeHashAdded` event on success.
     pub fn add_tee_hash(env: Env, hash: BytesN<32>) -> Result<(), VerificationError> {
-        // Retrieve the admin; reject if the contract has not been initialised.
         let admin: Address = env
             .storage()
             .persistent()
             .get(&DataKey::Admin)
             .ok_or(VerificationError::Unauthorized)?;
-
-        // Require that the transaction was authorised by the admin.
         admin.require_auth();
 
-        // Store the hash in persistent storage.
         env.storage()
             .persistent()
             .set(&DataKey::TeeHash(hash.clone()), &true);
 
-        // Emit TeeHashAdded event.
         #[allow(deprecated)]
         env.events().publish(
             (
@@ -108,6 +103,33 @@ impl Registry {
         Ok(())
     }
 
+    /// Remove a TEE hash from the registry.
+    /// Only the admin may call this function.
+    pub fn remove_tee_hash(env: Env, hash: BytesN<32>) -> Result<(), VerificationError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(VerificationError::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage().persistent().remove(&DataKey::TeeHash(hash.clone()));
+
+        #[allow(deprecated)]
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, "registry"),
+                soroban_sdk::Symbol::new(&env, "TeeHashRemoved"),
+                hash.clone(),
+            ),
+            TeeHashEventData {
+                hash: hash.clone(),
+            },
+        );
+
+        Ok(())
+    }
+
     /// Return whether `hash` is registered as a trusted TEE measurement.
     pub fn has_tee_hash(env: Env, hash: BytesN<32>) -> bool {
         env.storage()
@@ -116,8 +138,16 @@ impl Registry {
             .unwrap_or(false)
     }
 
-    /// Setup helper: Add a provider
-    pub fn add_provider(env: Env, provider: BytesN<32>) {
+    /// Add an authorized Oracle provider to the registry.
+    /// Only the admin may call this function.
+    pub fn add_provider(env: Env, provider: BytesN<32>) -> Result<(), VerificationError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(VerificationError::Unauthorized)?;
+        admin.require_auth();
+
         env.storage().persistent().set(&DataKey::Provider(provider.clone()), &true);
         #[allow(deprecated)]
         env.events().publish(
@@ -130,10 +160,20 @@ impl Registry {
                 provider: provider.clone(),
             },
         );
+
+        Ok(())
     }
 
-    /// Setup helper: Remove a provider
-    pub fn remove_provider(env: Env, provider: BytesN<32>) {
+    /// Remove an Oracle provider from the registry.
+    /// Only the admin may call this function.
+    pub fn remove_provider(env: Env, provider: BytesN<32>) -> Result<(), VerificationError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(VerificationError::Unauthorized)?;
+        admin.require_auth();
+
         env.storage().persistent().remove(&DataKey::Provider(provider.clone()));
         #[allow(deprecated)]
         env.events().publish(
@@ -146,22 +186,8 @@ impl Registry {
                 provider: provider.clone(),
             },
         );
-    }
 
-    /// Setup helper: Remove a TEE hash (admin-gated via require_auth on stored admin)
-    pub fn remove_tee_hash(env: Env, hash: BytesN<32>) {
-        env.storage().persistent().remove(&DataKey::TeeHash(hash.clone()));
-        #[allow(deprecated)]
-        env.events().publish(
-            (
-                soroban_sdk::Symbol::new(&env, "registry"),
-                soroban_sdk::Symbol::new(&env, "TeeHashRemoved"),
-                hash.clone(),
-            ),
-            TeeHashEventData {
-                hash: hash.clone(),
-            },
-        );
+        Ok(())
     }
 
     /// Setup helper: Create a pending request

--- a/docs/registry_events.md
+++ b/docs/registry_events.md
@@ -1,0 +1,90 @@
+# StellarProof Registry Events
+
+This document details the exact events emitted by the `registry` smart contract during state changes. These events are strictly standardized to allow indexers, backend APIs, and decentralized clients to subscribe to and filter registry modifications continuously without relying on frequent, expensive storage polls.
+
+All state transitions in the Provider and TEE Hash registries now automatically emit corresponding events.
+
+## Topic Convention
+
+Every registry event uses a two-topic structure:
+1.  **Protocol Tag:** `"registry"` (identifies the event family)
+2.  **Action Tag:** e.g., `"ProviderAdded"` (identifies the specific action)
+
+This structured format enables clients to selectively query via Soroban's event filters:
+*   **Track all registry activity:** Filter solely on `(Topic1 = "registry")`
+*   **Track specific registry changes:** Filter on `(Topic1 = "registry", Topic2 = "ProviderAdded")`
+
+---
+
+## 1. Provider Events
+
+### `ProviderAdded`
+Emitted when an authorized Oracle Provider is added to the registry.
+
+**Topics:**
+*   Topic 1: `Symbol("registry")`
+*   Topic 2: `Symbol("ProviderAdded")`
+*   Topic 3: `BytesN<32>` (The public key of the assigned provider)
+
+**Data Payload:**
+```rust
+struct ProviderEventData {
+    provider: BytesN<32>
+}
+```
+
+### `ProviderRemoved`
+Emitted when an Oracle Provider is removed from the registry.
+
+**Topics:**
+*   Topic 1: `Symbol("registry")`
+*   Topic 2: `Symbol("ProviderRemoved")`
+*   Topic 3: `BytesN<32>` (The public key of the removed provider)
+
+**Data Payload:**
+```rust
+struct ProviderEventData {
+    provider: BytesN<32>
+}
+```
+
+---
+
+## 2. TEE Hash Events
+
+### `TeeHashAdded`
+Emitted when a new Trusted Execution Environment (TEE) binary measurement hash is authorized.
+
+**Topics:**
+*   Topic 1: `Symbol("registry")`
+*   Topic 2: `Symbol("TeeHashAdded")`
+*   Topic 3: `BytesN<32>` (The exact SHA256/binary hash of the TEE image)
+
+**Data Payload:**
+```rust
+struct TeeHashEventData {
+    hash: BytesN<32>
+}
+```
+
+### `TeeHashRemoved`
+Emitted when an existing TEE hash is revoked or removed.
+
+**Topics:**
+*   Topic 1: `Symbol("registry")`
+*   Topic 2: `Symbol("TeeHashRemoved")`
+*   Topic 3: `BytesN<32>` (The hash being removed)
+
+**Data Payload:**
+```rust
+struct TeeHashEventData {
+    hash: BytesN<32>
+}
+```
+
+---
+
+## Indexing Considerations
+
+*   **Idempotency:** The contract utilizes the `set` operation. Adding an already existing provider will still trigger a `ProviderAdded` event, though the state effectively remains identical.
+*   **Failed Transactions:** Events are only published if the host's invocation successfully commits. Invalid transactions will not produce spurious logging.


### PR DESCRIPTION
This PR standardizes registry events (Provider/TEE) and enforces admin gating across all registry modification functions in the Registry contract. 

### Changes:
- Standardized event topics: Topic1='registry', Topic2='ActionTag', Topic3='Target'.
- Enforced admin authentication for dd_provider, emove_provider, and emove_tee_hash.
- Added corresponding unit tests in contracts/registry/src/test.rs.
- Added documentation in docs/registry_events.md.

Closes #27