### PR TITLE
feat: wallet error handling layer (#54)

### DIFF
--- a/frontend/app/context/ToastContext.tsx
+++ b/frontend/app/context/ToastContext.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useState } from 'react';
+
+type ToastVariant = 'error' | 'success' | 'info' | 'warning';
+
+interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextType {
+  showToast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextType>({ showToast: () => {} });
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, variant: ToastVariant = 'info') => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, variant }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000);
+  }, []);
+
+  const variantStyles: Record<ToastVariant, string> = {
+    error: 'bg-red-600',
+    success: 'bg-green-600',
+    warning: 'bg-yellow-500',
+    info: 'bg-blue-600',
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`${variantStyles[t.variant]} text-white text-sm px-4 py-3 rounded-lg shadow-lg max-w-sm`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastContext);

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import ScrollToTop from "@/components/ui/ScrollToTop";
 import "./globals.css";
 import { WalletProvider } from "../context/WalletContext";
 import { ThemeProvider } from "./context/ThemeContext";
+import { ToastProvider } from "./context/ToastContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -52,11 +53,13 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white dark:bg-darkblue text-gray-900 dark:text-gray-100 transition-colors duration-300`}
       >
         <ThemeProvider>
-          <WalletProvider>
-            {children}
-            <Footer />
-            <ScrollToTop />
-          </WalletProvider>
+          <ToastProvider>
+            <WalletProvider>
+              {children}
+              <Footer />
+              <ScrollToTop />
+            </WalletProvider>
+          </ToastProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,5 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: [
@@ -8,7 +7,10 @@ module.exports = {
     '**/*.(test|spec).+(ts|tsx|js)',
   ],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: { strict: false } }],
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/../$1',
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2510,7 +2509,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2594,7 +2592,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3114,7 +3111,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3629,7 +3625,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4455,7 +4450,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4641,7 +4635,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8336,7 +8329,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8346,7 +8338,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9362,7 +9353,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9634,7 +9624,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10156,7 +10145,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/utils/__tests__/walletErrors.test.ts
+++ b/frontend/src/utils/__tests__/walletErrors.test.ts
@@ -1,0 +1,24 @@
+import { handleWalletError, WalletErrorType } from '../walletErrors';
+
+describe('handleWalletError', () => {
+  const mockToast = jest.fn();
+
+  beforeEach(() => mockToast.mockClear());
+
+  const cases: [string, unknown, WalletErrorType][] = [
+    ['user rejected', 'User declined the request', WalletErrorType.USER_REJECTED],
+    ['user rejected (Error)', new Error('rejected by user'), WalletErrorType.USER_REJECTED],
+    ['network mismatch', 'Network mismatch detected', WalletErrorType.NETWORK_MISMATCH],
+    ['extension not found', 'Extension not found', WalletErrorType.EXTENSION_NOT_FOUND],
+    ['timeout', 'Request timed out', WalletErrorType.TIMEOUT],
+    ['auth failed', 'Unauthorized access', WalletErrorType.AUTHORIZATION_FAILED],
+    ['unknown', 'Something went wrong', WalletErrorType.UNKNOWN],
+    ['unknown (null)', null, WalletErrorType.UNKNOWN],
+  ];
+
+  test.each(cases)('%s → %s', (_label, error, expected) => {
+    const result = handleWalletError(error, mockToast);
+    expect(result).toBe(expected);
+    expect(mockToast).toHaveBeenCalledWith(expect.any(String), 'error');
+  });
+});

--- a/frontend/src/utils/walletErrors.ts
+++ b/frontend/src/utils/walletErrors.ts
@@ -1,0 +1,48 @@
+import { useToast } from '@/app/context/ToastContext';
+
+export enum WalletErrorType {
+  USER_REJECTED = 'USER_REJECTED',
+  NETWORK_MISMATCH = 'NETWORK_MISMATCH',
+  EXTENSION_NOT_FOUND = 'EXTENSION_NOT_FOUND',
+  TIMEOUT = 'TIMEOUT',
+  AUTHORIZATION_FAILED = 'AUTHORIZATION_FAILED',
+  UNKNOWN = 'UNKNOWN',
+}
+
+const ERROR_MESSAGES: Record<WalletErrorType, string> = {
+  [WalletErrorType.USER_REJECTED]: 'Connection request was rejected. Please approve it in Freighter and try again.',
+  [WalletErrorType.NETWORK_MISMATCH]: 'Network mismatch detected. Switch Freighter to the correct Stellar network.',
+  [WalletErrorType.EXTENSION_NOT_FOUND]: 'Freighter wallet not found. Please install the extension and refresh.',
+  [WalletErrorType.TIMEOUT]: 'The request timed out. Please check your connection and try again.',
+  [WalletErrorType.AUTHORIZATION_FAILED]: 'Authorization failed. Make sure Freighter has permission to connect.',
+  [WalletErrorType.UNKNOWN]: 'An unexpected wallet error occurred. Please try again.',
+};
+
+function classifyError(error: unknown): WalletErrorType {
+  const msg = (
+    typeof error === 'string' ? error :
+    error instanceof Error ? error.message :
+    typeof error === 'object' && error !== null && 'message' in error
+      ? String((error as { message: unknown }).message)
+      : ''
+  ).toLowerCase();
+
+  if (msg.includes('reject') || msg.includes('declined') || msg.includes('denied')) return WalletErrorType.USER_REJECTED;
+  if (msg.includes('network') || msg.includes('mismatch')) return WalletErrorType.NETWORK_MISMATCH;
+  if (msg.includes('not installed') || msg.includes('not found') || msg.includes('extension')) return WalletErrorType.EXTENSION_NOT_FOUND;
+  if (msg.includes('timeout') || msg.includes('timed out')) return WalletErrorType.TIMEOUT;
+  if (msg.includes('auth') || msg.includes('unauthorized') || msg.includes('forbidden')) return WalletErrorType.AUTHORIZATION_FAILED;
+  return WalletErrorType.UNKNOWN;
+}
+
+export function handleWalletError(error: unknown, showToast: (msg: string, variant: 'error') => void): WalletErrorType {
+  if (typeof window !== 'undefined' && window.location.hostname === 'localhost') console.error('[WalletError]', error);
+  const type = classifyError(error);
+  showToast(ERROR_MESSAGES[type], 'error');
+  return type;
+}
+
+export function useWalletError() {
+  const { showToast } = useToast();
+  return (error: unknown) => handleWalletError(error, showToast);
+}


### PR DESCRIPTION
- Add WalletErrorType enum with all known Freighter error types
- Add handleWalletError(error, showToast) utility function
- Add useWalletError() hook integrating with ToastContext
- Add ToastContext with error/success/warning/info variants
- Wire ToastProvider into app layout
- Add moduleNameMapper to jest config for @/ alias
- Add walletErrors.test.ts covering all error classifications

Closes #54