### PR TITLE
Jwt auth

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,11 @@ NODE_ENV=development
 
 # Example Cloud URI (MongoDB Atlas):
 MONGODB_URI=mongodb+srv://<username>:<password>@<cluster-url>/stellarproof?retryWrites=true&w=majority
+
+# JWT Configuration
+# ----------------------------------------------------------------------
+# IMPORTANT FOR CONTRIBUTORS:
+# Generate a strong secret for production (e.g., openssl rand -hex 64)
+# ----------------------------------------------------------------------
+JWT_SECRET=your_jwt_secret_here
+JWT_EXPIRES_IN=7d

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,11 +14,13 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.25",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.7.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.2"

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express';
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+import { authService } from '../services/auth.service';
+
+export const protect = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({
+      success: false,
+      message: 'Access denied. No bearer token provided.',
+    });
+    return;
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  if (!token) {
+    res.status(401).json({
+      success: false,
+      message: 'Access denied. Token is missing.',
+    });
+    return;
+  }
+
+  try {
+    const user = await authService.verifyTokenAndGetUser(token);
+    req.user = user;
+    next();
+  } catch (error) {
+    if (error instanceof TokenExpiredError) {
+      res.status(401).json({
+        success: false,
+        message: 'Token has expired. Please log in again.',
+      });
+      return;
+    }
+
+    if (error instanceof JsonWebTokenError) {
+      res.status(401).json({
+        success: false,
+        message: 'Invalid token. Authentication failed.',
+      });
+      return;
+    }
+
+    if (error instanceof Error) {
+      if (error.message === 'USER_NOT_FOUND') {
+        res.status(401).json({
+          success: false,
+          message: 'The user associated with this token no longer exists.',
+        });
+        return;
+      }
+
+      if (error.message === 'ACCOUNT_DEACTIVATED') {
+        res.status(403).json({
+          success: false,
+          message: 'This account has been deactivated.',
+        });
+        return;
+      }
+    }
+
+    res.status(500).json({
+      success: false,
+      message: 'An internal error occurred during authentication.',
+    });
+  }
+};

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,0 +1,32 @@
+import jwt from 'jsonwebtoken';
+import User, { IUser } from '../models/User.model';
+
+interface JwtPayload {
+  id: string;
+  iat: number;
+  exp: number;
+}
+
+class AuthService {
+  async verifyTokenAndGetUser(token: string): Promise<IUser> {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET environment variable is not configured');
+    }
+
+    const decoded = jwt.verify(token, secret) as JwtPayload;
+
+    const user = await User.findById(decoded.id);
+    if (!user) {
+      throw new Error('USER_NOT_FOUND');
+    }
+
+    if (!user.isActive) {
+      throw new Error('ACCOUNT_DEACTIVATED');
+    }
+
+    return user;
+  }
+}
+
+export const authService = new AuthService();

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,0 +1,11 @@
+import { IUser } from '../../models/User.model';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: IUser;
+    }
+  }
+}
+
+export {};

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {}]
+  }
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,7 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "types": ["jest", "@testing-library/jest-dom"],
+    "types": ["jest"],
     "plugins": [
       {
         "name": "next"

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
feat: add JWT authentication middleware closes #147 

Implements the `protect` middleware following the layered architecture
(Middleware → Service → Model). Extracts the Bearer token from the
Authorization header, verifies it via jsonwebtoken, and attaches the
resolved User document to `req.user` for downstream route handlers.

- backend/src/middlewares/auth.middleware.ts — protect middleware with
  granular error handling (expired, invalid, deactivated, not found)
- backend/src/services/auth.service.ts — AuthService.verifyTokenAndGetUser
  verifies JWT signature and queries the User model from MongoDB
- backend/src/types/express/index.d.ts — augments Express Request with
  optional `user: IUser` property
- backend/package.json — adds jsonwebtoken ^9.0.2 and @types/jsonwebtoken
- backend/.env.example — documents JWT_SECRET and JWT_EXPIRES_IN env vars

Closes #147
