### PR TITLE
feat(certificate): provenance certificate viewer with QR code and verified badge

### DIFF
--- a/frontend/app/certificate/[id]/page.tsx
+++ b/frontend/app/certificate/[id]/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { CertificateView } from "@/components/certificate/CertificateView";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  return {
+    title: `Certificate ${id} — StellarProof`,
+    description: "View and verify a StellarProof provenance certificate secured by Soroban smart contracts.",
+  };
+}
+
+export default async function CertificatePage({ params }: PageProps) {
+  const { id } = await params;
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-[#020617] py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        <CertificateView certificateId={id} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/certificate/CertificateView.tsx
+++ b/frontend/components/certificate/CertificateView.tsx
@@ -1,69 +1,191 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { ShieldCheck, Copy, CheckCircle, AlertTriangle } from "lucide-react";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { ExportActions, CertificateData } from "./ExportActions";
-import { fetchMockCertificate } from "@/services/certificateMock";
+import {
+  fetchCertificate,
+  getCertificateVerificationUrl,
+  ProvenanceCertificate,
+} from "@/services/certificate";
 
 interface CertificateViewProps {
   certificateId: string;
 }
 
-export function CertificateView({ certificateId }: CertificateViewProps) {
-  const [certificate, setCertificate] = useState<CertificateData | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
+function CertificateSkeleton() {
+  return (
+    <div className="p-6 bg-white dark:bg-darkblue rounded-lg shadow-glow space-y-6">
+      <div className="flex justify-between items-center">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-28 rounded-full" />
+          <Skeleton className="h-7 w-48" />
+        </div>
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+      <div className="space-y-4 border-t border-gray-100 dark:border-gray-800 pt-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex flex-col sm:flex-row sm:justify-between py-2 border-b border-gray-50 dark:border-gray-800/50 gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+        ))}
+      </div>
+      <div className="flex flex-col items-center gap-3 pt-2">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-36 w-36 rounded-xl" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+    </div>
+  );
+}
 
-  useEffect(() => {
-    const loadCertificate = async () => {
-      setLoading(true);
-      try {
-        const data = await fetchMockCertificate(certificateId);
-        setCertificate(data);
-      } catch (error) {
-        console.error("Failed to load certificate", error);
-      } finally {
-        setLoading(false);
-      }
-    };
+function HashField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
 
-    loadCertificate();
-  }, [certificateId]);
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable — silent fail
+    }
+  }
 
   return (
-    <div className="p-6 bg-white dark:bg-darkblue rounded-lg shadow-glow dark:shadow-glow-dark">
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Provenance Certificate
+    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center py-2 border-b border-gray-50 dark:border-gray-800/50 gap-1">
+      <span className="font-medium text-gray-500 dark:text-gray-400 shrink-0">{label}</span>
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-gray-900 dark:text-gray-100 font-mono text-xs break-all">
+          {value}
+        </span>
+        <button
+          onClick={handleCopy}
+          title="Copy full hash"
+          className="text-gray-400 hover:text-primary dark:hover:text-primary-light transition-colors shrink-0"
+        >
+          {copied ? (
+            <CheckCircle className="h-4 w-4 text-green-500" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function toCertificateData(cert: ProvenanceCertificate): CertificateData {
+  return {
+    owner: cert.ownerAddress,
+    certificate_id: cert.id,
+    manifest_hash: cert.manifestHash,
+    content_hash: cert.contentHash,
+    attestation_hash: cert.attestationHash,
+    timestamp: cert.mintedAt,
+    network: "Stellar",
+  };
+}
+
+export function CertificateView({ certificateId }: CertificateViewProps) {
+  const [certificate, setCertificate] = useState<ProvenanceCertificate | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      setCertificate(null);
+
+      const result = await fetchCertificate(certificateId);
+      if (cancelled) return;
+      if (result.error) {
+        setError(result.error);
+      } else {
+        setCertificate(result.data);
+      }
+      setLoading(false);
+    };
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [certificateId]);
+
+  if (loading) return <CertificateSkeleton />;
+
+  if (error) {
+    return (
+      <div className="p-6 bg-white dark:bg-darkblue rounded-lg shadow-glow flex flex-col items-center gap-4 py-16 text-center">
+        <AlertTriangle className="h-12 w-12 text-amber-500" />
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+          Certificate Not Found
         </h2>
-        {/* Integration with CertificateView component  */}
-        <ExportActions certificate={certificate} isLoading={loading} />
+        <p className="text-sm text-gray-600 dark:text-gray-400 max-w-md">{error}</p>
+      </div>
+    );
+  }
+
+  if (!certificate) return null;
+
+  const verificationUrl = getCertificateVerificationUrl(certificate.id);
+  const mintedDate = new Date(certificate.mintedAt).toLocaleString(undefined, {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+
+  return (
+    <div className="p-6 bg-white dark:bg-darkblue rounded-lg shadow-glow space-y-6">
+      <div className="flex flex-wrap justify-between items-center gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5 rounded-full px-3 py-1 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700">
+            <ShieldCheck className="h-4 w-4 text-emerald-500 dark:text-emerald-400" />
+            <span className="text-xs font-bold text-emerald-700 dark:text-emerald-300 tracking-wide uppercase">
+              Verified
+            </span>
+          </div>
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">
+            Provenance Certificate
+          </h2>
+        </div>
+        <ExportActions certificate={toCertificateData(certificate)} isLoading={false} />
       </div>
 
-      {loading ? (
-        <div className="animate-pulse space-y-4">
-          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2"></div>
-          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4"></div>
-          <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-full"></div>
+      <div className="space-y-0 border-t border-gray-100 dark:border-gray-800 text-sm">
+        <DetailRow label="Certificate ID" value={certificate.id} />
+        <DetailRow label="Owner" value={certificate.ownerAddress} />
+        <DetailRow label="Minted At" value={mintedDate} />
+        <DetailRow label="Network" value="Stellar" />
+        <HashField label="Manifest Hash" value={certificate.manifestHash} />
+        <HashField label="Content Hash" value={certificate.contentHash} />
+        <HashField label="Attestation Hash" value={certificate.attestationHash} />
+      </div>
+
+      <div className="flex flex-col items-center gap-3 pt-2">
+        <p className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider font-semibold">
+          Scan to verify
+        </p>
+        <div className="rounded-xl border border-gray-200 dark:border-white/10 p-3 bg-white shadow-md">
+          <QRCodeSVG value={verificationUrl} size={140} level="M" includeMargin={false} />
         </div>
-      ) : certificate ? (
-        <div className="space-y-4 border-t border-gray-100 dark:border-gray-800 pt-4 text-sm">
-          <DetailRow label="Owner" value={certificate.owner} />
-          <DetailRow label="Certificate ID" value={certificate.certificate_id} />
-          <DetailRow label="Manifest Hash" value={certificate.manifest_hash} />
-          <DetailRow label="Content Hash" value={certificate.content_hash} />
-          <DetailRow label="Attestation Hash" value={certificate.attestation_hash} />
-          <DetailRow label="Timestamp" value={String(certificate.timestamp)} />
-          <DetailRow label="Network" value={certificate.network} />
-        </div>
-      ) : (
-        <div className="text-red-500">Failed to load certificate data.</div>
-      )}
+        <p className="text-xs text-gray-400 dark:text-gray-500 break-all text-center max-w-xs">
+          {verificationUrl}
+        </p>
+      </div>
     </div>
   );
 }
 
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center py-2 border-b border-gray-50 dark:border-gray-800/50">
+    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center py-2 border-b border-gray-50 dark:border-gray-800/50 gap-1">
       <span className="font-medium text-gray-500 dark:text-gray-400">{label}</span>
       <span className="text-gray-900 dark:text-gray-100 font-mono text-xs sm:text-sm mt-1 sm:mt-0 break-all">
         {value}
@@ -71,3 +193,5 @@ function DetailRow({ label, value }: { label: string; value: string }) {
     </div>
   );
 }
+
+export default CertificateView;

--- a/frontend/components/certificate/CertificateView.tsx
+++ b/frontend/components/certificate/CertificateView.tsx
@@ -108,7 +108,7 @@ export function CertificateView({ certificateId }: CertificateViewProps) {
       if (result.error) {
         setError(result.error);
       } else {
-        setCertificate(result.data);
+        setCertificate(result.data ?? null);
       }
       setLoading(false);
     };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.468.0",
     "next": "16.1.6",
     "prismjs": "^1.30.0",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-dropzone": "^15.0.0",

--- a/frontend/services/certificate.ts
+++ b/frontend/services/certificate.ts
@@ -1,0 +1,42 @@
+export interface ProvenanceCertificate {
+  id: string;
+  ownerAddress: string;
+  mintedAt: string;
+  manifestHash: string;
+  contentHash: string;
+  attestationHash: string;
+}
+
+type CertificateResult =
+  | { data: ProvenanceCertificate; error?: undefined }
+  | { data?: undefined; error: string };
+
+const MOCK_CERTIFICATES: Record<string, ProvenanceCertificate> = {
+  "cert-demo-001": {
+    id: "cert-demo-001",
+    ownerAddress: "GBVBK2TX7QHEQNIMUPBVPZ7EONL52TWKQ7OXFDJPAJPYGNZFACUQBXP",
+    mintedAt: "2024-11-15T10:30:00Z",
+    manifestHash: "0xa1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    contentHash: "0xb2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+    attestationHash: "0xc3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4",
+  },
+};
+
+export async function fetchCertificate(id: string): Promise<CertificateResult> {
+  // Replace with real contract call once Provenance Contract is deployed
+  await new Promise((res) => setTimeout(res, 800));
+
+  const cert = MOCK_CERTIFICATES[id];
+  if (!cert) {
+    return { error: "Certificate not found. The ID may be invalid or the certificate may not exist on-chain." };
+  }
+  return { data: cert };
+}
+
+export function getCertificateVerificationUrl(id: string): string {
+  const base =
+    typeof window !== "undefined"
+      ? `${window.location.protocol}//${window.location.host}`
+      : process.env.NEXT_PUBLIC_APP_URL ?? "https://stellarproof.app";
+  return `${base}/certificate/${id}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -3801,6 +3804,11 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -9122,6 +9130,10 @@ snapshots:
   pure-color@1.3.0: {}
 
   pure-rand@7.0.1: {}
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Rewrites `CertificateView` to show a green **Verified** badge (ShieldCheck icon), all certificate fields (Owner, Certificate ID, Minted At, Manifest Hash, Content Hash, Attestation Hash, Network), copy-to-clipboard on every hash, a QR code via `qrcode.react` pointing to the public shareable URL, and a `Skeleton`-component loader from the design system
- Adds `services/certificate.ts` with mock data in the service layer and a `getCertificateVerificationUrl` helper — marked for replacement once the Provenance Contract is deployed
- Graceful `AlertTriangle` error panel for invalid/missing certificate IDs
- Adds public Next.js 15 route at `app/certificate/[id]/page.tsx` with `generateMetadata`

## Test plan

- [ ] `/certificate/cert-demo-001` shows Verified badge, all 7 fields, QR code, and share URL
- [ ] `/certificate/invalid-id` shows "Certificate Not Found" error panel
- [ ] Skeleton renders for ~800 ms before data appears
- [ ] Copy button on each hash copies the full value to clipboard
- [ ] QR code scans to the correct `/certificate/[id]` URL
- [ ] Light and dark modes both render correctly per the style guide

Closes #83