### PR TITLE
feat(ipfs): IPFS upload service via Pinata — Controller→Service→Route architecture

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,3 +37,12 @@ CLOUDINARY_API_SECRET=your_api_secret
 # Generate with: openssl rand -hex 32
 # ----------------------------------------------------------------------
 KMS_MASTER_KEY=your_64_char_hex_master_key_here
+
+# IPFS / Pinata Configuration
+# ----------------------------------------------------------------------
+# Generate a JWT at https://app.pinata.cloud/keys (API v3, scoped to
+# pinFileToIPFS and pinJSONToIPFS). The gateway URL is your Pinata
+# dedicated gateway or the public gateway (no auth required).
+# ----------------------------------------------------------------------
+PINATA_JWT=your_pinata_jwt_here
+PINATA_GATEWAY_URL=https://gateway.pinata.cloud/ipfs

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",
+    "pinata": "^2.5.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -55,4 +55,10 @@ export const env = {
 
   /** JWT expiry duration, e.g. '7d', '24h' */
   JWT_EXPIRES_IN: optionalEnv("JWT_EXPIRES_IN", "7d"),
+
+  /** Pinata JWT for IPFS uploads (v3 API) */
+  PINATA_JWT: requireEnv("PINATA_JWT"),
+
+  /** Pinata public gateway base URL */
+  PINATA_GATEWAY_URL: optionalEnv("PINATA_GATEWAY_URL", "https://gateway.pinata.cloud/ipfs"),
 } as const;

--- a/backend/src/controllers/ipfs.controller.ts
+++ b/backend/src/controllers/ipfs.controller.ts
@@ -1,0 +1,66 @@
+import type { Request, Response, NextFunction } from "express";
+import { StatusCodes } from "http-status-codes";
+import { ipfsService } from "../services/ipfs.service";
+import type { IpfsUploadInput } from "../types/ipfs.types";
+
+export class IpfsController {
+  async uploadFile(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const file = req.file;
+      if (!file) {
+        res.status(StatusCodes.BAD_REQUEST).json({
+          success: false,
+          error: "No file provided. Send a multipart/form-data request with a 'file' field.",
+        });
+        return;
+      }
+
+      const input: IpfsUploadInput = {
+        content: file.buffer,
+        name: file.originalname,
+        metadata: { mimetype: file.mimetype },
+      };
+
+      const result = await ipfsService.upload(input);
+
+      res.status(StatusCodes.CREATED).json({ success: true, data: result });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async uploadJson(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const body = req.body as Record<string, unknown>;
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        res.status(StatusCodes.BAD_REQUEST).json({
+          success: false,
+          error: "Request body must be a JSON object.",
+        });
+        return;
+      }
+
+      const { name, metadata, ...payload } = body as {
+        name?: string;
+        metadata?: Record<string, string>;
+        [key: string]: unknown;
+      };
+
+      const input: IpfsUploadInput = {
+        content: payload,
+        name: typeof name === "string" ? name : "document",
+        metadata: metadata && typeof metadata === "object" && !Array.isArray(metadata)
+          ? metadata
+          : {},
+      };
+
+      const result = await ipfsService.upload(input);
+
+      res.status(StatusCodes.CREATED).json({ success: true, data: result });
+    } catch (err) {
+      next(err);
+    }
+  }
+}
+
+export const ipfsController = new IpfsController();

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -10,6 +10,7 @@ import manifestRoutes from "./manifest.routes";
 import developerRoutes from "./developer.routes";
 import authRoutes from "./auth.routes";
 import userRoutes from "./user.routes";
+import ipfsRoutes from "./ipfs.routes";
 
 const router = Router();
 
@@ -32,5 +33,6 @@ router.use("/api/v1/verification/jobs", verificationRoutes);
 router.use("/api/v1/developer", developerRoutes);
 router.use("/api/v1/auth", authRoutes);
 router.use("/api/v1/users", userRoutes);
+router.use("/api/v1/ipfs", ipfsRoutes);
 
 export default router;

--- a/backend/src/routes/ipfs.routes.ts
+++ b/backend/src/routes/ipfs.routes.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import multer from "multer";
+import { ipfsController } from "../controllers/ipfs.controller";
+
+const router = Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 100 * 1024 * 1024 },
+});
+
+/**
+ * POST /api/v1/ipfs/upload/file
+ * Upload a binary file to IPFS via Pinata.
+ * Accepts multipart/form-data with a single 'file' field.
+ * Returns: { success: true, data: { cid, size, name, timestamp, gatewayUrl } }
+ */
+router.post(
+  "/upload/file",
+  upload.single("file"),
+  ipfsController.uploadFile.bind(ipfsController)
+);
+
+/**
+ * POST /api/v1/ipfs/upload/json
+ * Upload a JSON document to IPFS via Pinata.
+ * Accepts application/json body. Optional 'name' and 'metadata' fields are
+ * extracted; the rest of the body becomes the pinned document.
+ * Returns: { success: true, data: { cid, size, name, timestamp, gatewayUrl } }
+ */
+router.post(
+  "/upload/json",
+  ipfsController.uploadJson.bind(ipfsController)
+);
+
+export default router;

--- a/backend/src/services/ipfs.service.ts
+++ b/backend/src/services/ipfs.service.ts
@@ -1,0 +1,62 @@
+import { PinataSDK } from "pinata";
+import { StatusCodes } from "http-status-codes";
+import { env } from "../config/env";
+import { AppError } from "../errors/AppError";
+import type { IpfsUploadInput, IpfsUploadResult } from "../types/ipfs.types";
+
+class IpfsService {
+  private readonly pinata: PinataSDK;
+
+  constructor() {
+    this.pinata = new PinataSDK({
+      pinataJwt: env.PINATA_JWT,
+      pinataGateway: env.PINATA_GATEWAY_URL,
+    });
+  }
+
+  async upload(input: IpfsUploadInput): Promise<IpfsUploadResult> {
+    const { content, name = "upload", metadata = {} } = input;
+
+    try {
+      let file: File;
+
+      if (Buffer.isBuffer(content)) {
+        file = new File([content], name, { type: "application/octet-stream" });
+      } else {
+        const json = JSON.stringify(content);
+        file = new File([json], `${name}.json`, { type: "application/json" });
+      }
+
+      const response = await this.pinata.upload.public.file(file).addMetadata({
+        name,
+        keyValues: metadata,
+      });
+
+      const cid: string = response.cid;
+      const size: number = response.size ?? (Buffer.isBuffer(content) ? content.byteLength : Buffer.byteLength(JSON.stringify(content)));
+
+      return {
+        cid,
+        size,
+        name: response.name ?? name,
+        timestamp: new Date().toISOString(),
+        gatewayUrl: `${env.PINATA_GATEWAY_URL}/${cid}`,
+      };
+    } catch (err: unknown) {
+      if (err instanceof AppError) throw err;
+
+      const message =
+        err instanceof Error
+          ? err.message
+          : "IPFS upload failed — unknown error";
+
+      throw new AppError(
+        `IPFS upload failed: ${message}`,
+        StatusCodes.BAD_GATEWAY,
+        "IPFS_UPLOAD_FAILED"
+      );
+    }
+  }
+}
+
+export const ipfsService = new IpfsService();

--- a/backend/src/types/ipfs.types.ts
+++ b/backend/src/types/ipfs.types.ts
@@ -1,0 +1,13 @@
+export interface IpfsUploadResult {
+  cid: string;
+  size: number;
+  name: string;
+  timestamp: string;
+  gatewayUrl: string;
+}
+
+export interface IpfsUploadInput {
+  content: Buffer | Record<string, unknown>;
+  name?: string;
+  metadata?: Record<string, string>;
+}

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -75,7 +75,8 @@ export default function ContactPage() {
     setValue,
     watch,
   } = useForm<ContactFormInputs>({
-    resolver: zodResolver(contactSchema),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(contactSchema as any),
     mode: "onBlur",
     defaultValues: {
       fullName: "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       node-cron:
         specifier: ^4.2.1
         version: 4.2.1
+      pinata:
+        specifier: ^2.5.5
+        version: 2.5.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -3731,6 +3734,18 @@ packages:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  pinata@2.5.5:
+    resolution: {integrity: sha512-GmHGL8bSpiwQlbrXrT73DJ1ZrYi+MD3lY7scY10D2PnH0kggDCUP04Gb96thbRenhvqVYjPRYYFt7gW9yjejYw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -9053,6 +9068,11 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  pinata@2.5.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   pirates@4.0.7: {}
 


### PR DESCRIPTION
## Summary

- Adds `IpfsService` wrapping Pinata SDK v3 — accepts a `Buffer` (binary file) or plain JSON object and returns `{ cid, size, name, timestamp, gatewayUrl }`
- Adds `IpfsController` with `uploadFile` (multipart/form-data, 100 MB limit via multer) and `uploadJson` endpoints; all errors propagate through the project's global `AppError` handler with `BAD_GATEWAY` status
- Registers `POST /api/v1/ipfs/upload/file` and `POST /api/v1/ipfs/upload/json` in the versioned root router
- Full TypeScript typings in `types/ipfs.types.ts`; no unhandled promise rejections
- `PINATA_JWT` and `PINATA_GATEWAY_URL` added to `config/env.ts` and documented in `.env.example`
- Also fixes pre-existing upstream build error: `@hookform/resolvers` 5.2.2 was typed against Zod 4.0.x internals; `zod@4.3.6` changed `_zod.version.minor` from `0` to `3`, breaking the overload. Added `as any` cast at the resolver call site in `app/contact/page.tsx`

## Test plan

- [ ] `POST /api/v1/ipfs/upload/file` with a binary file → `201 { success: true, data: { cid, size, name, timestamp, gatewayUrl } }`
- [ ] `POST /api/v1/ipfs/upload/json` with a JSON body → `201` same shape
- [ ] Missing `file` field → `400`
- [ ] Invalid `PINATA_JWT` → `502` with `IPFS_UPLOAD_FAILED` code
- [ ] CID verifiable at `https://gateway.pinata.cloud/ipfs/<cid>`

Closes #161