### PR TITLE
Implement forgot password

### DIFF
--- a/backend/src/__tests__/auth.service.test.ts
+++ b/backend/src/__tests__/auth.service.test.ts
@@ -1,5 +1,5 @@
 import { AuthService } from '../services/auth.service';
-import { AppError } from '../errors/AppError';
+import crypto from 'crypto';
 
 jest.mock('../models/User.model', () => ({
   __esModule: true,
@@ -26,7 +26,10 @@ function makeUser(overrides: Record<string, unknown> = {}) {
     role: 'creator',
     isActive: true,
     stellarPublicKey: undefined,
+    resetPasswordToken: undefined,
+    resetPasswordExpires: undefined,
     comparePassword: jest.fn().mockResolvedValue(true),
+    save: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -107,5 +110,51 @@ describe('AuthService.login', () => {
     mockFindOne(makeUser({ stellarPublicKey: key }));
     const result = await service.login('user@example.com', 'pass');
     expect(result.user.stellarPublicKey).toBe(key);
+  });
+});
+
+describe('AuthService.forgotPassword', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    service = new AuthService();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('hashes and stores a reset password token for an existing user', async () => {
+    const rawToken = 'a'.repeat(64);
+    const hashedToken = crypto.createHash('sha256').update(rawToken).digest('hex');
+    jest.spyOn(crypto, 'randomBytes').mockReturnValue(Buffer.from(rawToken, 'hex') as never);
+
+    const user = makeUser({
+      resetPasswordToken: undefined,
+      resetPasswordExpires: undefined,
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    mockFindOne(user);
+
+    const result = await service.forgotPassword(' USER@example.com ');
+
+    expect(mockedFindOne).toHaveBeenCalledWith({ email: 'user@example.com' });
+    expect(user.resetPasswordToken).toBe(hashedToken);
+    expect(user.resetPasswordToken).not.toBe(rawToken);
+    expect(user.resetPasswordExpires).toBeInstanceOf(Date);
+    expect((user.resetPasswordExpires as Date).getTime()).toBeGreaterThan(Date.now());
+    expect(user.save).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      message: 'If an account with that email exists, a password reset link has been sent.',
+    });
+  });
+
+  it('returns success without saving when the email does not exist', async () => {
+    mockFindOne(null);
+
+    const result = await service.forgotPassword('missing@example.com');
+
+    expect(result).toEqual({
+      message: 'If an account with that email exists, a password reset link has been sent.',
+    });
   });
 });

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -114,3 +114,29 @@ export const register = async (
     next(err);
   }
 };
+
+/**
+ * POST /api/v1/auth/forgot-password
+ */
+export const forgotPassword = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { email } = req.body as { email?: unknown };
+
+    if (typeof email !== 'string') {
+      return next(new AppError('Email must be a string', 400, 'INVALID_INPUT'));
+    }
+
+    const result = await authService.forgotPassword(email);
+
+    res.status(200).json({
+      success: true,
+      message: result.message,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { login, register } from '../controllers/auth.controller';
+import { forgotPassword, login, register } from '../controllers/auth.controller';
 
 const router = Router();
 
@@ -16,5 +16,12 @@ router.post('/login', login);
  * @access Public
  */
 router.post('/register', register);
+
+/**
+ * @route  POST /api/v1/auth/forgot-password
+ * @desc   Request a password reset token
+ * @access Public
+ */
+router.post('/forgot-password', forgotPassword);
 
 export default router;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import User, { IUser } from '../models/User.model';
 import { AppError } from '../errors/AppError';
 import { env } from '../config/env';
@@ -27,6 +28,10 @@ export interface RegisterResult {
     isActive: boolean;
     createdAt: Date;
   };
+}
+
+export interface ForgotPasswordResult {
+  message: string;
 }
 
 export class AuthService {
@@ -127,9 +132,44 @@ export class AuthService {
       },
     };
   }
+
+  async forgotPassword(email: string): Promise<ForgotPasswordResult> {
+    const normalizedEmail = email.toLowerCase().trim();
+    if (!normalizedEmail) {
+      throw new AppError('Email is required', 400, 'EMAIL_REQUIRED');
+    }
+
+    const successMessage = 'If an account with that email exists, a password reset link has been sent.';
+
+    const user = await User.findOne({ email: normalizedEmail })
+      .select('+resetPasswordToken +resetPasswordExpires')
+      .exec();
+
+    if (!user) {
+      return { message: successMessage };
+    }
+
+    const resetToken = crypto.randomBytes(32).toString('hex');
+    const hashedToken = crypto.createHash('sha256').update(resetToken).digest('hex');
+
+    user.resetPasswordToken = hashedToken;
+    user.resetPasswordExpires = new Date(Date.now() + 10 * 60 * 1000);
+    await user.save();
+
+    await this.sendPasswordResetEmail(user.email, resetToken);
+
+    return { message: successMessage };
+  }
+
+  private async sendPasswordResetEmail(email: string, token: string): Promise<void> {
+    void email;
+    void token;
+    // TODO: Replace this no-op with an email provider integration.
+  }
 }
 
 export const authService = new AuthService();
 
 // Standalone helper for direct imports
 export const registerUser = (input: RegisterInput) => authService.register(input);
+export const forgotPassword = (email: string) => authService.forgotPassword(email);


### PR DESCRIPTION
## Summary

Implemented the forgot password request flow for auth users.

## Changes

- Added `POST /api/v1/auth/forgot-password`
- Generates a secure password reset token
- Hashes the token before saving it to `resetPasswordToken`
- Sets a reset token expiry timestamp
- Mocked password reset email sending for now
- Returns a generic success response to avoid leaking whether an email exists
- Added focused service tests for the forgot password flow

## Related Issue
Closes #148 
