### PR TITLE
done

### DIFF
--- a/backend/src/controllers/manifest.controller.ts
+++ b/backend/src/controllers/manifest.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
+import { AppError } from '../errors/AppError';
 import { manifestService } from '../services/manifest.service';
 import type { ListManifestsQuery } from '../types/manifest.types';
 
@@ -29,6 +30,11 @@ class ManifestController {
   public async createManifest(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       const manifestPayload = req.body;
+      const user = req.user;
+
+      if (!user) {
+        throw new AppError('Authentication required', StatusCodes.UNAUTHORIZED, 'AUTH_REQUIRED');
+      }
 
       if (!manifestPayload || typeof manifestPayload !== 'object') {
         res.status(StatusCodes.BAD_REQUEST).json({
@@ -38,7 +44,8 @@ class ManifestController {
         return;
       }
 
-      const savedManifest = await manifestService.createManifest(manifestPayload);
+      const validatedManifest = manifestService.prepareManifestPayload(manifestPayload, user);
+      const savedManifest = await manifestService.createManifest(validatedManifest);
 
       res.status(StatusCodes.CREATED).json({
         success: true,

--- a/backend/src/routes/manifest.routes.ts
+++ b/backend/src/routes/manifest.routes.ts
@@ -13,6 +13,7 @@ import { Router } from "express";
 import { z } from "zod";
 import type { Request, Response, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
+import { verifyJWT } from '../middlewares/jwt.middleware';
 import { manifestController } from "../controllers/manifest.controller";
 
 // ---------------------------------------------------------------------------
@@ -52,6 +53,25 @@ const listManifestsQuerySchema = z.object({
     ),
 });
 
+const createManifestBodySchema = z.object({
+  contentHash: z.string().min(1, "contentHash is required"),
+  creator: z
+    .string()
+    .regex(STELLAR_PUBLIC_KEY_REGEX, "Invalid Stellar public key (G...)")
+    .optional(),
+  timestamp: z
+    .preprocess((value) => {
+      if (typeof value === "string") {
+        return new Date(value);
+      }
+      return value;
+    }, z.date().refine((date) => !Number.isNaN(date.getTime()), {
+      message: "Invalid timestamp",
+    }))
+    .optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).strict();
+
 // ---------------------------------------------------------------------------
 // Query validation middleware
 // ---------------------------------------------------------------------------
@@ -70,9 +90,26 @@ function validateListManifestsQuery(
     });
     return;
   }
-  // Overwrite req.query with the coerced + validated values so the controller
-  // receives already-parsed numbers rather than raw strings.
   req.query = result.data as unknown as typeof req.query;
+  next();
+}
+
+function validateCreateManifestBody(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const result = createManifestBodySchema.safeParse(req.body);
+  if (!result.success) {
+    res.status(StatusCodes.BAD_REQUEST).json({
+      success: false,
+      error: "Invalid manifest payload",
+      details: result.error.flatten().fieldErrors,
+    });
+    return;
+  }
+
+  req.body = result.data as unknown as typeof req.body;
   next();
 }
 
@@ -90,6 +127,17 @@ router.get(
   "/",
   validateListManifestsQuery,
   manifestController.listManifests.bind(manifestController)
+);
+
+/**
+ * POST /api/v1/manifests
+ * Authenticated endpoint for saving a generated manifest.
+ */
+router.post(
+  "/",
+  verifyJWT,
+  validateCreateManifestBody,
+  manifestController.createManifest.bind(manifestController)
 );
 
 export default router;

--- a/backend/src/services/manifest.service.ts
+++ b/backend/src/services/manifest.service.ts
@@ -2,14 +2,37 @@
  * Manifest Service – business logic for retrieving and creating manifests.
  */
 import { StatusCodes } from "http-status-codes";
+import { z } from "zod";
 import { SPVModel } from "../models/spv.model";
 import ManifestModel, { IManifest } from "../models/Manifest.model";
 import { AppError } from "../errors/AppError";
+import type { IUser } from "../models/User.model";
 import type {
   IManifestEntry,
   ListManifestsQuery,
   ManifestListResult,
 } from "../types/manifest.types";
+
+const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
+const createManifestBodySchema = z.object({
+  contentHash: z.string().min(1, "contentHash is required"),
+  creator: z
+    .string()
+    .regex(STELLAR_PUBLIC_KEY_REGEX, "Invalid Stellar public key (G...)")
+    .optional(),
+  timestamp: z
+    .preprocess((value) => {
+      if (typeof value === "string") {
+        return new Date(value);
+      }
+      return value;
+    }, z.date().refine((date) => !Number.isNaN(date.getTime()), {
+      message: "Invalid timestamp",
+    }))
+    .optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).strict();
 
 const EXCLUDED_FIELDS = { encryptedPayload: 0 } as const;
 
@@ -49,6 +72,45 @@ class ManifestService {
     ]);
 
     return { manifests, total, limit, skip };
+  }
+
+  public prepareManifestPayload(payload: unknown, user: IUser): Partial<IManifest> {
+    const result = createManifestBodySchema.safeParse(payload);
+    if (!result.success) {
+      throw new AppError(
+        "Invalid manifest payload",
+        StatusCodes.BAD_REQUEST,
+        "INVALID_MANIFEST_PAYLOAD"
+      );
+    }
+
+    const { contentHash, creator, timestamp, metadata } = result.data;
+    const userPublicKey = user.stellarPublicKey;
+
+    if (userPublicKey && creator && creator !== userPublicKey) {
+      throw new AppError(
+        "Creator public key does not match authenticated user",
+        StatusCodes.FORBIDDEN,
+        "CREATOR_MISMATCH"
+      );
+    }
+
+    const effectiveCreator = userPublicKey ?? creator;
+    if (!effectiveCreator) {
+      throw new AppError(
+        "Creator public key is required when the authenticated user has no connected wallet",
+        StatusCodes.BAD_REQUEST,
+        "CREATOR_REQUIRED"
+      );
+    }
+
+    return {
+      contentHash,
+      creator: effectiveCreator,
+      creatorId: user.id,
+      timestamp: timestamp ?? new Date(),
+      metadata,
+    };
   }
 
   /**

--- a/backend/src/types/manifest.types.ts
+++ b/backend/src/types/manifest.types.ts
@@ -37,3 +37,10 @@ export interface ManifestListResult {
   limit: number;
   skip: number;
 }
+
+export interface CreateManifestPayload {
+  contentHash: string;
+  creator?: string;
+  timestamp?: Date;
+  metadata?: Record<string, unknown>;
+}


### PR DESCRIPTION
Manifest Create API Implemented

Normalizes timestamp and metadata
Keeps creation via Mongoose model so response data comes from MongoDB
Added manifest parsing/validation logic in the service layer
Enforces authenticated creator ownership
Saves the manifest through the service and returns the generated document ID

closes #154 
close #155