### PR TITLE
feat: implement forget password UI and verification page

### DIFF
--- a/frontend/app/forget-password/page.tsx
+++ b/frontend/app/forget-password/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useForm, SubmitHandler } from "react-hook-form";
+
+interface ForgetPasswordFormValues {
+  email: string;
+}
+
+export default function ForgetPasswordPage() {
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgetPasswordFormValues>({
+    mode: "onBlur",
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit: SubmitHandler<ForgetPasswordFormValues> = () => {
+    router.push("/verify-new-password");
+  };
+
+  const inputBase =
+    "w-full px-4 py-2.5 rounded-lg border text-sm bg-white dark:bg-darkblue-dark text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none transition";
+  const inputNormal = `${inputBase} border-gray-300 dark:border-gray-600 focus:ring-2 focus:ring-primary`;
+  const inputError = `${inputBase} border-red-500 focus:ring-2 focus:ring-red-500`;
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-darkblue dark:bg-darkblue-dark px-4 py-10">
+      <div className="w-full max-w-md bg-white dark:bg-darkblue rounded-2xl shadow-glow p-8">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-primary">Forgot Password</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Enter your email address and we&apos;ll send you a one-time verification code.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-5">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Email Address
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              className={errors.email ? inputError : inputNormal}
+              {...register("email", {
+                required: "Email is required",
+                pattern: {
+                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                  message: "Please enter a valid email address",
+                },
+              })}
+            />
+            {errors.email && (
+              <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full py-2.5 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary-dark transition-all duration-200 flex items-center justify-center disabled:opacity-60 shadow-button-glow"
+          >
+            {isSubmitting ? "Sending code..." : "Send OTP"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/verify-new-password/page.tsx
+++ b/frontend/app/verify-new-password/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+
+export default function VerifyNewPasswordPage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-darkblue dark:bg-darkblue-dark px-4 py-10">
+      <div className="w-full max-w-md bg-white dark:bg-darkblue rounded-2xl shadow-glow p-8">
+        <div className="mb-8 text-center">
+          <h1 className="text-2xl font-bold text-primary">Verify New Password</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Use the code sent to your email to verify your request and set a new password.
+          </p>
+        </div>
+
+        <div className="space-y-5">
+          <div>
+            <label
+              htmlFor="otp"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Verification Code
+            </label>
+            <input
+              id="otp"
+              type="text"
+              autoComplete="one-time-code"
+              placeholder="123456"
+              className="w-full px-4 py-2.5 rounded-lg border border-gray-300 dark:border-gray-600 text-sm bg-white dark:bg-darkblue-dark text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary transition"
+            />
+          </div>
+
+          <button
+            type="button"
+            className="w-full py-2.5 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary-dark transition-all duration-200 shadow-button-glow"
+          >
+            Verify Code
+          </button>
+        </div>
+
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
+          Return to {" "}
+          <Link href="/login" className="text-primary font-medium hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/auth/LoginForm.tsx
+++ b/frontend/components/auth/LoginForm.tsx
@@ -134,7 +134,7 @@ export default function LoginForm() {
           Remember me
         </label>
         <a
-          href="/forgot-password"
+          href="/forget-password"
           className="text-sm text-primary hover:underline"
         >
           Forgot your password?

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@react-pdf/renderer": "^4.3.2",
     "@stellar/freighter-api": "^6.0.1",
     "@tanstack/react-query": "^5.100.6",
+    "@testing-library/dom": "^10.4.1",
     "clsx": "^2.1.1",
     "fast-xml-parser": "^5.4.1",
     "framer-motion": "^11.15.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,6 @@
       }
     ],
     "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./*"]
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,7 @@
       }
     ],
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./*"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.6
         version: 5.100.8(react@19.2.3)
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "strict": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
close  #283 



## PR Summary

Implement the new “Forget Password” UI flow for StellarProof frontend.

### What changed

- Added page.tsx
  - New responsive page
  - Email input with React Hook Form validation
  - Submit button navigates to verification page

- Added page.tsx
  - OTP verification placeholder page
  - Supports redirect target after forget-password submission

- Updated LoginForm.tsx
  - Fixed forgot-password link to `/forget-password`

- Updated TypeScript configs
  - Added `"ignoreDeprecations": "6.0"` to tsconfig.base.json and tsconfig.json

### Testing

- Installed frontend dependencies with `npm install --legacy-peer-deps`
- Validated frontend types with `npx tsc --noEmit --pretty false`
- No TypeScript errors remain after validation

### Notes

- This is a UI-only implementation for the password recovery entry point.
- The verify page is currently a UI placeholder that can be extended with OTP and password-reset behavior later.

Closes #283