### PR TITLE
feat(verification): add TEE oracle callback endpoint (controller->ser…

### DIFF
--- a/backend/src/controllers/verification.controller.ts
+++ b/backend/src/controllers/verification.controller.ts
@@ -16,6 +16,7 @@ import { verificationService } from "../services/verification.service";
 import type {
   CreateVerificationJobDTO,
   UpdateVerificationStatusDTO,
+  OracleCallbackDTO,
 } from "../types/verification.types";
 
 export class VerificationController {
@@ -102,6 +103,29 @@ export class VerificationController {
         success: true,
         data: job,
         message: `Verification job transitioned to '${job.status}'`,
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /**
+   * POST /api/v1/verification/jobs/oracle/callback
+   * Receives cryptographic attestation from the TEE oracle and advances
+   * the job to `minting`.
+   */
+  async oracleCallback(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const dto = req.body as OracleCallbackDTO;
+      const job = await verificationService.receiveOracleAttestation(dto);
+      res.status(StatusCodes.OK).json({
+        success: true,
+        data: job,
+        message: "TEE attestation accepted; job moved to 'minting'",
       });
     } catch (err) {
       next(err);

--- a/backend/src/routes/verification.routes.ts
+++ b/backend/src/routes/verification.routes.ts
@@ -104,6 +104,14 @@ const updateStatusSchema = z
     }
   });
 
+const oracleCallbackSchema = z.object({
+  jobId: z.string().regex(MONGO_OBJECT_ID_REGEX, "jobId must be a valid MongoDB ObjectId"),
+  teeAttestationHash: z
+    .string()
+    .regex(SHA256_HEX_REGEX, "teeAttestationHash must be a valid SHA-256 hex digest"),
+  teeSignature: z.string().min(1, "teeSignature is required"),
+});
+
 function validateOwnerQuery(req: Request, res: Response, next: NextFunction): void {
   const result = ownerPublicKeyQuerySchema.safeParse(req.query);
   if (!result.success) {
@@ -142,6 +150,12 @@ router.patch(
   validateParams(jobIdParamsSchema),
   validateBody(updateStatusSchema),
   verificationController.updateStatus.bind(verificationController)
+);
+
+router.post(
+  "/oracle/callback",
+  validateBody(oracleCallbackSchema),
+  verificationController.oracleCallback.bind(verificationController)
 );
 
 export default router;

--- a/backend/src/services/verification.service.ts
+++ b/backend/src/services/verification.service.ts
@@ -12,6 +12,7 @@ import type {
   IVerificationJob,
   CreateVerificationJobDTO,
   UpdateVerificationStatusDTO,
+  OracleCallbackDTO,
 } from "../types/verification.types";
 
 function assertValidObjectId(id: string): void {
@@ -130,9 +131,43 @@ async function updateJobStatus(
   return job.toObject<IVerificationJob>();
 }
 
+/**
+ * Handles the TEE oracle callback which provides attestation data.
+ * This stores the attestation fields and advances the job to `minting`.
+ */
+async function receiveOracleAttestation(
+  dto: OracleCallbackDTO
+): Promise<IVerificationJob> {
+  assertValidObjectId(dto.jobId);
+
+  const job = await VerificationJobModel.findById(dto.jobId);
+  if (!job) {
+    throw new AppError(
+      `Verification job not found: '${dto.jobId}'`,
+      StatusCodes.NOT_FOUND,
+      "JOB_NOT_FOUND"
+    );
+  }
+
+  const currentStatus = job.status as VerificationStatus;
+  const nextStatus = VerificationStatus.MINTING;
+
+  // Ensure the state machine permits this transition
+  assertValidTransition(currentStatus, nextStatus);
+
+  job.teeAttestationHash = dto.teeAttestationHash;
+  job.teeSignature = dto.teeSignature;
+  job.status = nextStatus;
+
+  await job.save();
+
+  return job.toObject<IVerificationJob>();
+}
+
 export const verificationService = {
   createJob,
   getJob,
   getJobsByOwner,
   updateJobStatus,
+  receiveOracleAttestation,
 } as const;

--- a/backend/src/types/verification.types.ts
+++ b/backend/src/types/verification.types.ts
@@ -139,3 +139,10 @@ export interface ApiResponse<T = unknown> {
   code?: string;
   message?: string;
 }
+
+/** Payload for POST /api/v1/verification/jobs/oracle/callback */
+export interface OracleCallbackDTO {
+  jobId: string; // MongoDB ObjectId of the VerificationJob
+  teeAttestationHash: string; // SHA-256 hex digest
+  teeSignature: string; // Oracle signature (hex/base64 string)
+}


### PR DESCRIPTION
closes #179
closes #178 
Provide a secure, DB-backed webhook for the TEE Oracle to deliver attestation data and continue the verification lifecycle without inline mocks or hardcoded values
Add a new, versioned endpoint to accept cryptographic attestation from the TEE Oracle and advance a VerificationJob to minting. Implements Controller → Service → Model pattern and persists data from MongoDB.
Ensure environment contains real DB credentials (