### PR TITLE
Add storage upload endpoints and verification submit flow

### DIFF
--- a/backend/src/controllers/storage.controller.ts
+++ b/backend/src/controllers/storage.controller.ts
@@ -3,6 +3,8 @@ import { StatusCodes } from 'http-status-codes';
 import mongoose from 'mongoose';
 import { AppError } from '../errors/AppError';
 import Asset from '../models/Asset.model';
+import Manifest from '../models/Manifest.model';
+import { ipfsService } from '../services/ipfs.service';
 import { storageOrchestratorService } from '../services/storage.service';
 import { StorageError, type StorageProvider } from '../types/storage.types';
 
@@ -125,6 +127,55 @@ export const uploadMedia = async (req: Request, res: Response, next: NextFunctio
         assetId: asset._id,
         url: uploadResult.url,
         cid: uploadResult.cid,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const uploadManifest = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { manifestId } = req.body;
+
+    if (!manifestId || !mongoose.Types.ObjectId.isValid(manifestId)) {
+      throw new AppError('Valid manifestId is required', StatusCodes.BAD_REQUEST, 'INVALID_MANIFEST_ID');
+    }
+
+    const manifest = await Manifest.findById(manifestId);
+    if (!manifest) {
+      throw new AppError('Manifest not found', StatusCodes.NOT_FOUND, 'MANIFEST_NOT_FOUND');
+    }
+
+    const manifestObject = manifest.toObject();
+    const { __v, ipfsCid, ipfsUrl, ipfsUploadedAt, ...manifestPayload } = manifestObject as any;
+    void __v;
+    void ipfsCid;
+    void ipfsUrl;
+    void ipfsUploadedAt;
+
+    const manifestBuffer = Buffer.from(JSON.stringify(manifestPayload), 'utf8');
+    const uploadResult = await ipfsService.upload({
+      content: manifestBuffer,
+      name: `manifest-${manifest._id}.json`,
+      metadata: {
+        manifestId: manifest._id.toString(),
+        manifestHash: manifest.manifestHash || '',
+      },
+    });
+
+    manifest.ipfsCid = uploadResult.cid;
+    manifest.ipfsUrl = uploadResult.gatewayUrl;
+    manifest.ipfsUploadedAt = new Date(uploadResult.timestamp);
+    await manifest.save();
+
+    res.status(StatusCodes.OK).json({
+      success: true,
+      message: 'Manifest uploaded to IPFS successfully',
+      data: {
+        manifestId: manifest._id,
+        cid: manifest.ipfsCid,
+        url: manifest.ipfsUrl,
       },
     });
   } catch (error) {

--- a/backend/src/controllers/storage.controller.ts
+++ b/backend/src/controllers/storage.controller.ts
@@ -1,6 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import mongoose from 'mongoose';
+import { AppError } from '../errors/AppError';
+import Asset from '../models/Asset.model';
 import { storageOrchestratorService } from '../services/storage.service';
-import { StorageError } from '../types/storage.types';
+import { StorageError, type StorageProvider } from '../types/storage.types';
 
 /**
  * Storage Controller
@@ -62,6 +66,68 @@ export const uploadFile = async (req: Request, res: Response, next: NextFunction
     });
   } catch (error) {
     // Let error handler middleware process all errors
+    next(error);
+  }
+};
+
+function getAuthenticatedUserId(req: Request): string | undefined {
+  const user = req.user as any;
+  return user?.id || user?._id?.toString() || req.body.userId;
+}
+
+export const uploadMedia = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (!req.file) {
+      throw new AppError(
+        "No file provided. Send multipart/form-data with a 'file' field.",
+        StatusCodes.BAD_REQUEST,
+        'NO_FILE_PROVIDED'
+      );
+    }
+
+    const storageProvider = req.body.storageProvider || 'ipfs';
+    const userId = getAuthenticatedUserId(req);
+
+    if (!userId) {
+      throw new AppError(
+        'User authentication required or userId must be provided in request body.',
+        StatusCodes.UNAUTHORIZED,
+        'AUTH_REQUIRED'
+      );
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      throw new AppError('Invalid userId', StatusCodes.BAD_REQUEST, 'INVALID_USER_ID');
+    }
+
+    const uploadResult = await storageOrchestratorService.orchestrate({
+      storageProvider: storageProvider as StorageProvider,
+      buffer: req.file.buffer,
+      mimetype: req.file.mimetype,
+      originalname: req.file.originalname,
+      userId,
+    });
+
+    const asset = await Asset.create({
+      creatorId: new mongoose.Types.ObjectId(userId),
+      fileName: req.file.originalname,
+      mimeType: req.file.mimetype,
+      sizeBytes: uploadResult.size,
+      storageProvider: uploadResult.provider,
+      storageReferenceId: uploadResult.cid || uploadResult.url,
+      isEncrypted: false,
+    });
+
+    res.status(StatusCodes.CREATED).json({
+      success: true,
+      message: 'Media uploaded successfully',
+      data: {
+        assetId: asset._id,
+        url: uploadResult.url,
+        cid: uploadResult.cid,
+      },
+    });
+  } catch (error) {
     next(error);
   }
 };

--- a/backend/src/controllers/verification.controller.ts
+++ b/backend/src/controllers/verification.controller.ts
@@ -12,13 +12,92 @@
  */
 import type { Request, Response, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
+import mongoose from "mongoose";
+import { AppError } from "../errors/AppError";
+import Asset from "../models/Asset.model";
+import Manifest from "../models/Manifest.model";
+import { VerificationJobModel } from "../models/verificationJob.model";
 import { verificationService } from "../services/verification.service";
 import type {
   CreateVerificationJobDTO,
   UpdateVerificationStatusDTO,
 } from "../types/verification.types";
+import { VerificationStatus } from "../types/verification.types";
 
 export class VerificationController {
+  /**
+   * POST /api/v1/verify/submit
+   * Validates ownership and creates a pending Truth Engine verification job.
+   */
+  async submit(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    try {
+      const { manifestId, assetId } = req.body as {
+        manifestId?: string;
+        assetId?: string;
+      };
+      const user = req.user as any;
+      const userId = user?.id || user?._id?.toString();
+
+      if (!userId) {
+        throw new AppError("Authentication required", StatusCodes.UNAUTHORIZED, "AUTH_REQUIRED");
+      }
+
+      if (!manifestId || !mongoose.Types.ObjectId.isValid(manifestId)) {
+        throw new AppError("Valid manifestId is required", StatusCodes.BAD_REQUEST, "INVALID_MANIFEST_ID");
+      }
+
+      if (!assetId || !mongoose.Types.ObjectId.isValid(assetId)) {
+        throw new AppError("Valid assetId is required", StatusCodes.BAD_REQUEST, "INVALID_ASSET_ID");
+      }
+
+      const [manifest, asset] = await Promise.all([
+        Manifest.findById(manifestId),
+        Asset.findById(assetId),
+      ]);
+
+      if (!manifest) {
+        throw new AppError("Manifest not found", StatusCodes.NOT_FOUND, "MANIFEST_NOT_FOUND");
+      }
+
+      if (!asset) {
+        throw new AppError("Asset not found", StatusCodes.NOT_FOUND, "ASSET_NOT_FOUND");
+      }
+
+      if (manifest.creatorId.toString() !== userId || asset.creatorId.toString() !== userId) {
+        throw new AppError(
+          "Authenticated user does not own both the manifest and asset",
+          StatusCodes.FORBIDDEN,
+          "OWNERSHIP_MISMATCH"
+        );
+      }
+
+      const job = await VerificationJobModel.create({
+        manifestId: new mongoose.Types.ObjectId(manifestId),
+        assetId: new mongoose.Types.ObjectId(assetId),
+        ownerPublicKey: user.stellarPublicKey || manifest.creator,
+        contentHash: manifest.contentHash,
+        status: VerificationStatus.PENDING,
+      });
+
+      res.status(StatusCodes.CREATED).json({
+        success: true,
+        message: "Verification job submitted successfully",
+        data: {
+          jobId: job._id,
+          status: job.status,
+          manifestId: job.manifestId,
+          assetId: job.assetId,
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+
   /**
    * POST /api/v1/verification/jobs
    * Creates a new VerificationJob in the `pending` state.

--- a/backend/src/models/Manifest.model.ts
+++ b/backend/src/models/Manifest.model.ts
@@ -20,6 +20,9 @@ export interface IManifest extends Document {
     [key: string]: any;          // Allow arbitrary additional metadata
   };
   manifestHash?: string;         // The hash of this entire manifest document
+  ipfsCid?: string;
+  ipfsUrl?: string;
+  ipfsUploadedAt?: Date;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -56,6 +59,16 @@ const ManifestSchema: Schema = new Schema(
       type: String,
       unique: true,
       sparse: true,
+    },
+    ipfsCid: {
+      type: String,
+      index: true,
+    },
+    ipfsUrl: {
+      type: String,
+    },
+    ipfsUploadedAt: {
+      type: Date,
     }
   },
   { 

--- a/backend/src/models/verificationJob.model.ts
+++ b/backend/src/models/verificationJob.model.ts
@@ -20,6 +20,18 @@ const ALL_STATUSES = Object.values(VerificationStatus);
 
 const VerificationJobSchema = new Schema<VerificationJobDocument>(
   {
+    manifestId: {
+      type: Schema.Types.ObjectId,
+      ref: "Manifest",
+      index: true,
+      default: undefined,
+    },
+    assetId: {
+      type: Schema.Types.ObjectId,
+      ref: "Asset",
+      index: true,
+      default: undefined,
+    },
     ownerPublicKey: {
       type: String,
       required: [true, "ownerPublicKey is required"],

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -13,6 +13,7 @@ import userRoutes from "./user.routes";
 import ipfsRoutes from "./ipfs.routes";
 import mediaRoutes from "./media.routes";
 import storageRoutes from "./v1/storage.routes";
+import verifyRoutes from "./v1/verification.routes";
 
 const router = Router();
 
@@ -38,5 +39,6 @@ router.use("/api/v1/users", userRoutes);
 router.use("/api/v1/ipfs", ipfsRoutes);
 router.use("/api/v1/media", mediaRoutes);
 router.use("/api/v1/storage", storageRoutes);
+router.use("/api/v1/verify", verifyRoutes);
 
 export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -12,6 +12,7 @@ import authRoutes from "./auth.routes";
 import userRoutes from "./user.routes";
 import ipfsRoutes from "./ipfs.routes";
 import mediaRoutes from "./media.routes";
+import storageRoutes from "./v1/storage.routes";
 
 const router = Router();
 
@@ -36,5 +37,6 @@ router.use("/api/v1/auth", authRoutes);
 router.use("/api/v1/users", userRoutes);
 router.use("/api/v1/ipfs", ipfsRoutes);
 router.use("/api/v1/media", mediaRoutes);
+router.use("/api/v1/storage", storageRoutes);
 
 export default router;

--- a/backend/src/routes/v1/storage.routes.ts
+++ b/backend/src/routes/v1/storage.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import multer from 'multer';
-import { uploadFile, uploadMedia } from '../../controllers/storage.controller';
+import { uploadFile, uploadManifest, uploadMedia } from '../../controllers/storage.controller';
 
 /**
  * Storage Routes - v1
@@ -40,5 +40,6 @@ const upload = multer({
  */
 router.post('/upload', upload.single('file'), uploadFile);
 router.post('/media', upload.single('file'), uploadMedia);
+router.post('/manifest', uploadManifest);
 
 export default router;

--- a/backend/src/routes/v1/storage.routes.ts
+++ b/backend/src/routes/v1/storage.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import multer from 'multer';
-import { uploadFile } from '../../controllers/storage.controller';
+import { uploadFile, uploadMedia } from '../../controllers/storage.controller';
 
 /**
  * Storage Routes - v1
@@ -39,5 +39,6 @@ const upload = multer({
  *   - 502: Provider error (upstream failure)
  */
 router.post('/upload', upload.single('file'), uploadFile);
+router.post('/media', upload.single('file'), uploadMedia);
 
 export default router;

--- a/backend/src/routes/v1/verification.routes.ts
+++ b/backend/src/routes/v1/verification.routes.ts
@@ -1,5 +1,9 @@
 import { Router } from 'express';
+import { protect } from '../../middlewares/auth.middleware';
+import { verificationController } from '../../controllers/verification.controller';
 
 const router = Router();
+
+router.post('/submit', protect, verificationController.submit.bind(verificationController));
 
 export default router;

--- a/backend/src/services/cleanup.ts
+++ b/backend/src/services/cleanup.ts
@@ -32,7 +32,9 @@ export class CleanupService {
    * These assets are "linked" and must NOT be deleted.
    */
   private async getLinkedAssetIds(): Promise<mongoose.Types.ObjectId[]> {
-    const jobs = await VerificationJobModel.distinct('assetId').exec();
+    const jobs = await VerificationJobModel.distinct('assetId').exec() as unknown as Array<
+      string | mongoose.Types.ObjectId | null | undefined
+    >;
     return jobs
       .filter((id): id is string | mongoose.Types.ObjectId => Boolean(id))
       .map((id) =>

--- a/backend/src/services/cleanup.ts
+++ b/backend/src/services/cleanup.ts
@@ -33,7 +33,13 @@ export class CleanupService {
    */
   private async getLinkedAssetIds(): Promise<mongoose.Types.ObjectId[]> {
     const jobs = await VerificationJobModel.distinct('assetId').exec();
-    return jobs as mongoose.Types.ObjectId[];
+    return jobs
+      .filter((id): id is string | mongoose.Types.ObjectId => Boolean(id))
+      .map((id) =>
+        id instanceof mongoose.Types.ObjectId
+          ? id
+          : new mongoose.Types.ObjectId(id),
+      );
   }
 
 

--- a/backend/src/types/verification.types.ts
+++ b/backend/src/types/verification.types.ts
@@ -69,6 +69,10 @@ export const VALID_TRANSITIONS: Readonly<
 export interface IVerificationJob {
   _id?: string;
 
+  /** Manifest and asset submitted for this verification run. */
+  manifestId?: string;
+  assetId?: string;
+
   /** Stellar G-address of the user who submitted the job. */
   ownerPublicKey: string;
 

--- a/frontend/components/WalletModal.tsx
+++ b/frontend/components/WalletModal.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   ChevronDown,
   Wallet,
+  UserCircle,
 } from "lucide-react";
 import { useWallet } from "@/context/WalletContext";
 import { FREIGHTER_INSTALL_URL } from "@/services/wallet";
@@ -83,6 +84,15 @@ export function WalletModal() {
             transition={{ duration: 0.2 }}
             className="absolute right-0 mt-2 w-56 overflow-hidden rounded-xl border border-white/10 bg-darkblue/95 p-1 shadow-lg backdrop-blur-md z-50"
           >
+            <a
+              role="menuitem"
+              href="/launch"
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-white/90 transition hover:bg-white/10 hover:text-white cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-inset"
+              onClick={() => setIsOpen(false)}
+            >
+              <UserCircle className="h-4 w-4" aria-hidden="true" />
+              Access Account
+            </a>
             <button
               role="menuitem"
               onClick={() => {


### PR DESCRIPTION
- Added POST /api/v1/storage/media to upload media via Multer, call the storage orchestrator, create an Asset document, and return the Asset ID with URL/CID.
- Added POST /api/v1/storage/manifest to upload stored manifests to IPFS and persist CID metadata on Manifest documents.
- Added POST /api/v1/verify/submit to validate manifest and asset ownership before creating a pending VerificationJob.
- Updated the Launch App header dropdown with Access Account, Connect Wallet, and Install Freighter options.

Closes #163 
Closes #164 
Closes #177 
Closes #281 