### PR TITLE
Ignored deployment builds for PRs from contributors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "github": {
+    "enabled": true,
+    "silent": true
+  }
+}


### PR DESCRIPTION
Disable Vercel's automatic preview deployments for PRs from contributors,

Ignore Builds for Non-Main Branches via vercel.json