### PR TITLE
feat: add skeleton loading states to dashboard and vault pages

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import {
   type VerificationStatus,
 } from "@/services/verificationService";
 import Link from "next/link";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50];
 
@@ -81,6 +82,89 @@ function WalletPrompt() {
   );
 }
 
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Controls skeleton */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <Skeleton className="h-4 w-32" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-8 rounded" />
+          <Skeleton className="h-8 w-8 rounded" />
+          <Skeleton className="h-8 w-8 rounded" />
+        </div>
+      </div>
+
+      {/* Desktop Table skeleton */}
+      <div className="hidden overflow-hidden rounded-xl border border-gray-200 dark:border-white/10 sm:block">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-white/10">
+          <thead className="bg-gray-50 dark:bg-white/5">
+            <tr>
+              {["Date", "Request ID", "Content Hash", "Status", "Actions"].map((h) => (
+                <th
+                  key={h}
+                  className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+                >
+                  <Skeleton className="h-4 w-20" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-white/10 bg-white dark:bg-darkblue">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <tr key={i} className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Skeleton className="h-4 w-24" />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Skeleton className="h-4 w-32" />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Skeleton className="h-4 w-28" />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Skeleton className="h-6 w-20 rounded-full" />
+                </td>
+                <td className="whitespace-nowrap px-6 py-4">
+                  <Skeleton className="h-4 w-12" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile Cards skeleton */}
+      <div className="flex flex-col gap-3 sm:hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-darkblue p-4 shadow-sm"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-20 mb-1" />
+            <Skeleton className="h-3 w-28 mb-3" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination skeleton */}
+      <div className="mt-6 flex items-center justify-between">
+        <Skeleton className="h-4 w-28" />
+        <div className="flex gap-2">
+          <Skeleton className="h-10 w-24 rounded-lg" />
+          <Skeleton className="h-10 w-20 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { isConnected, publicKey } = useWallet();
   const [requests, setRequests] = useState<VerificationRequest[]>([]);
@@ -145,12 +229,7 @@ export default function DashboardPage() {
         {!isConnected ? (
           <WalletPrompt />
         ) : isLoading ? (
-          <div className="flex items-center justify-center py-24">
-            <svg className="h-8 w-8 animate-spin text-primary" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-            </svg>
-          </div>
+          <DashboardSkeleton />
         ) : requests.length === 0 ? (
           <EmptyState />
         ) : (

--- a/frontend/app/vault/page.tsx
+++ b/frontend/app/vault/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Calendar,
   ChevronLeft,
@@ -15,6 +15,7 @@ import {
 import Header from "../../components/Header";
 import { useWallet } from "@/context/WalletContext";
 import { cn } from "../../utils/cn";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 import { VaultActions } from "../../components/vault/VaultActions";
 import { DecryptionPreview } from "../../components/vault/DecryptionPreview";
@@ -260,6 +261,86 @@ function EmptyState() {
   );
 }
 
+function VaultSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Controls skeleton */}
+      <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 p-4 space-y-4">
+        <Skeleton className="h-10 w-full rounded-xl" />
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-9 w-full rounded-lg" />
+          </div>
+        </div>
+      </div>
+
+      {/* Table skeleton */}
+      <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left" aria-label="Vault items loading">
+            <thead>
+              <tr className="border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-white/[0.02]">
+                {["Storage ID", "Filename", "Date", "Size", "Status", "Actions"].map((h) => (
+                  <th
+                    key={h}
+                    scope="col"
+                    className="px-4 py-3 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider whitespace-nowrap"
+                  >
+                    <Skeleton className="h-4 w-20" />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 8 }).map((_, i) => (
+                <tr key={i} className="border-b border-gray-100 dark:border-gray-800">
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-28" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-36" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-24" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-4 w-16" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <Skeleton className="h-5 w-20 rounded-full" />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1.5">
+                      <Skeleton className="h-7 w-7 rounded-lg" />
+                      <Skeleton className="h-7 w-7 rounded-lg" />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Footer skeleton */}
+        <div className="px-4 py-3 border-t border-gray-100 dark:border-gray-800 flex items-center justify-between gap-4 flex-wrap">
+          <Skeleton className="h-4 w-48" />
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-8 w-8 rounded-lg" />
+            <Skeleton className="h-8 w-8 rounded-lg" />
+            <Skeleton className="h-8 w-8 rounded-lg" />
+            <Skeleton className="h-8 w-8 rounded-lg" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ---- Vault Table Row ----------------------------------------------- */
 
 interface RowProps {
@@ -421,6 +502,20 @@ export default function VaultPage() {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
   const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isConnected) {
+      setIsLoading(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [isConnected]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -611,7 +706,9 @@ export default function VaultPage() {
 
             {/* Table / empty state */}
             <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 overflow-hidden">
-              {pageItems.length === 0 ? (
+              {isLoading ? (
+                <VaultSkeleton />
+              ) : pageItems.length === 0 ? (
                 <EmptyState />
               ) : (
                 <>

--- a/frontend/app/vault/page.tsx
+++ b/frontend/app/vault/page.tsx
@@ -504,18 +504,15 @@ export default function VaultPage() {
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    if (!isConnected) {
-      setIsLoading(false);
-      return;
-    }
-
+ useEffect(() => {
+    if (!isConnected) return;
     const timer = setTimeout(() => {
       setIsLoading(false);
     }, 500);
-
     return () => clearTimeout(timer);
   }, [isConnected]);
+
+  const showSkeleton = isConnected && isLoading;
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -706,7 +703,7 @@ export default function VaultPage() {
 
             {/* Table / empty state */}
             <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 overflow-hidden">
-              {isLoading ? (
+              {showSkeleton ? (
                 <VaultSkeleton />
               ) : pageItems.length === 0 ? (
                 <EmptyState />


### PR DESCRIPTION
Closes #292

Adds skeleton loading states (using the existing Skeleton.tsx component) to the dashboard and vault pages, replacing basic spinners during data fetching.

Changes

frontend/app/dashboard/page.tsx: skeleton loading state while fetching requests
frontend/app/vault/page.tsx: skeleton loading state added

Notes

Certificate Viewer (CertificateView.tsx) skeleton not yet covered in this PR — can follow up separately if needed