### PR TITLE
[Frontend] [Enhancement] Implement Toggle functionality between List and Grid Views for Search Results

### DIFF
--- a/frontend/app/search/components/GridView.tsx
+++ b/frontend/app/search/components/GridView.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Clock,
+  User,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Skeleton } from "../../../components/ui/Skeleton";
+import type { SearchResult } from "../types";
+import {
+  truncateHash,
+  truncateAddress,
+  formatDate,
+  STATUS_ICON_BIG,
+  StatusBadge,
+  CopyButton,
+  EmptyState,
+} from "./shared";
+
+/* ------------------------------------------------------------------ */
+/*                              Types                                 */
+/* ------------------------------------------------------------------ */
+
+export interface GridViewProps {
+  /** The array of search results to render. */
+  results: SearchResult[];
+  /** When true, render skeleton card placeholders instead of data. */
+  isLoading?: boolean;
+  /** Message shown when `results` is empty (and not loading). */
+  emptyMessage?: string;
+  /** Optional callback invoked when the user requests more results. */
+  onLoadMore?: () => void;
+  /** Whether more results are available (shows "Load more" affordance). */
+  hasMore?: boolean;
+}
+
+
+interface SearchResultCardProps {
+  result: SearchResult;
+}
+
+function SearchResultCard({ result }: SearchResultCardProps) {
+  const {
+    id,
+    name,
+    description,
+    hash,
+    creator,
+    mintedAt,
+    status,
+    network = "Stellar",
+    type,
+  } = result;
+
+  const displayTitle =
+    name?.trim() || `Certificate #${truncateHash(id, 4, 4)}`;
+
+  const certHref = `/certificate/${encodeURIComponent(id)}`;
+
+  return (
+    <motion.article
+      layout
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.25 }}
+      className={cn(
+        "group relative flex flex-col rounded-2xl border bg-white dark:bg-white/5",
+        "border-gray-200 dark:border-white/10",
+        "hover:border-primary/50 dark:hover:border-primary/40",
+        "hover:shadow-lg hover:shadow-primary/5 dark:hover:shadow-primary/10",
+        "focus-within:border-primary/60",
+        "transition-all duration-200",
+        "h-full",
+      )}
+    >
+      {/* Card header with status icon and badge */}
+      <div className="p-4 sm:p-5 pb-0">
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div
+            className={cn(
+              "shrink-0 h-10 w-10 sm:h-11 sm:w-11 flex items-center justify-center rounded-xl",
+              "bg-gradient-to-br border",
+              status === "verified" &&
+                "from-green-500/15 to-green-500/5 border-green-500/20 text-green-600 dark:text-green-400",
+              status === "pending" &&
+                "from-yellow-500/15 to-yellow-500/5 border-yellow-500/20 text-yellow-600 dark:text-yellow-400",
+              status === "failed" &&
+                "from-red-500/15 to-red-500/5 border-red-500/20 text-red-600 dark:text-red-400",
+            )}
+            aria-hidden
+          >
+            {STATUS_ICON_BIG[status]}
+          </div>
+          <div className="flex items-center gap-2 flex-wrap justify-end">
+            {type && (
+              <span className="inline-flex items-center rounded-md bg-gray-100 dark:bg-white/5 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300">
+                {type}
+              </span>
+            )}
+            <StatusBadge status={status} />
+          </div>
+        </div>
+
+        {/* Title */}
+        <h3 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-white line-clamp-2 mb-1.5">
+          <Link
+            href={certHref}
+            aria-label={`View certificate ${displayTitle}`}
+            className={cn(
+              "relative outline-none",
+              "after:absolute after:inset-0 after:content-['']",
+              "hover:text-primary dark:hover:text-primary-light",
+              "focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:rounded-sm",
+              "transition-colors",
+            )}
+          >
+            {displayTitle}
+          </Link>
+        </h3>
+
+        {/* Description */}
+        {description && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mb-3">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {/* Spacer to push metadata to bottom */}
+      <div className="flex-1" />
+
+      {/* Metadata section */}
+      <div className="p-4 sm:p-5 pt-0 space-y-2">
+        {/* Hash */}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 shrink-0">
+            Hash
+          </span>
+          <code
+            className="font-mono text-xs text-gray-700 dark:text-gray-300 truncate"
+            title={hash || "Unavailable"}
+          >
+            {truncateHash(hash)}
+          </code>
+          <CopyButton value={hash || ""} label="hash" />
+        </div>
+
+        {/* Creator */}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <User
+            className="w-3 h-3 shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden
+          />
+          <span
+            className="font-mono text-xs text-gray-600 dark:text-gray-400 truncate"
+            title={creator}
+          >
+            {truncateAddress(creator)}
+          </span>
+        </div>
+
+        {/* Date + Network row */}
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <div className="flex items-center gap-1.5">
+            <Clock
+              className="w-3 h-3 shrink-0 text-gray-400 dark:text-gray-500"
+              aria-hidden
+            />
+            <time
+              dateTime={mintedAt}
+              className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap"
+            >
+              {formatDate(mintedAt)}
+            </time>
+          </div>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-primary/80 dark:text-primary-light">
+            {network}
+          </span>
+        </div>
+      </div>
+
+      {/* Footer with view action */}
+      <div className="px-4 pb-3 sm:px-5 sm:pb-4 flex items-center justify-end gap-1">
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-[11px] font-semibold",
+            "text-gray-500 dark:text-gray-400",
+            "bg-gray-50 dark:bg-white/5",
+            "group-hover:text-primary group-hover:bg-primary/10 dark:group-hover:bg-primary/20",
+            "transition-colors",
+          )}
+        >
+          View
+          <ChevronRight
+            className="w-3 h-3 group-hover:translate-x-0.5 transition-transform"
+            aria-hidden
+          />
+        </span>
+      </div>
+    </motion.article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*                          Card component                            */
+/* ------------------------------------------------------------------ */
+
+/* ------------------------------------------------------------------ */
+/*                       Loading skeleton                             */
+/* ------------------------------------------------------------------ */
+
+function GridViewSkeleton({ cards = 6 }: { cards?: number }) {
+  return (
+    <div
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5"
+      role="list"
+      aria-busy="true"
+      aria-label="Loading search results"
+    >
+      {Array.from({ length: cards }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 p-4 sm:p-5"
+        >
+          <div className="flex items-start justify-between gap-3 mb-3">
+            <Skeleton className="h-10 w-10 sm:h-11 sm:w-11 rounded-xl shrink-0" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
+          <Skeleton className="h-4 w-3/4 mb-2" />
+          <Skeleton className="h-3 w-full mb-1" />
+          <Skeleton className="h-3 w-2/3 mb-4" />
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*                             Component                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * `GridView` — global certificate search results, card grid orientation.
+ *
+ * Renders one card per `SearchResult` with key metadata (hash, creator,
+ * date, status). Each card uses a stretched-link pattern, so the title
+ * is the actual `<a>` element while clicks anywhere on the card
+ * navigate to `/certificate/[id]`. Responsive: 1 col on mobile,
+ * 2 cols on tablet, 3 cols on desktop.
+ */
+export function GridView({
+  results,
+  isLoading = false,
+  emptyMessage = "No certificates match your search.",
+  onLoadMore,
+  hasMore = false,
+}: GridViewProps) {
+  if (isLoading) {
+    return <GridViewSkeleton />;
+  }
+
+  if (results.length === 0) {
+    return <EmptyState message={emptyMessage} />;
+  }
+
+  return (
+    <section aria-label="Search results" className="space-y-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5">
+        <AnimatePresence mode="popLayout" initial={false}>
+          {results.map((result, index) => (
+            <motion.div
+              key={result.id}
+              layout
+              initial={{ opacity: 0, y: 12 }}
+              animate={{
+                opacity: 1,
+                y: 0,
+                transition: { delay: Math.min(index * 0.04, 0.4) },
+              }}
+              exit={{ opacity: 0, y: -8 }}
+            >
+              <SearchResultCard result={result} />
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      </div>
+
+      {hasMore && onLoadMore && (
+        <div className="flex justify-center pt-2">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className={cn(
+              "inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium",
+              "border border-gray-300 dark:border-white/10",
+              "bg-white dark:bg-white/5",
+              "text-gray-700 dark:text-gray-300",
+              "hover:border-primary dark:hover:border-primary",
+              "hover:text-primary dark:hover:text-primary-light",
+              "transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            )}
+          >
+            Load more results
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default GridView;

--- a/frontend/app/search/components/ListView.tsx
+++ b/frontend/app/search/components/ListView.tsx
@@ -1,0 +1,516 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  Loader2,
+  Copy,
+  Check,
+  Search,
+  Clock,
+  User,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "../../../utils/cn";
+import { Skeleton } from "../../../components/ui/Skeleton";
+import type { SearchResult, SearchResultStatus } from "../types";
+
+/* ------------------------------------------------------------------ */
+/*                              Types                                 */
+/* ------------------------------------------------------------------ */
+
+export interface ListViewProps {
+  /** The array of search results to render. */
+  results: SearchResult[];
+  /** When true, render skeleton row placeholders instead of data. */
+  isLoading?: boolean;
+  /** Message shown when `results` is empty (and not loading). */
+  emptyMessage?: string;
+  /** Optional callback invoked when the user requests more results. */
+  onLoadMore?: () => void;
+  /** Whether more results are available (shows "Load more" affordance). */
+  hasMore?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/*                              Helpers                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Middle-truncate a hash so the full hash remains inspectable while
+ * keeping the list row compact (e.g. `0x1a2b…f0e1`).
+ */
+function truncateHash(hash?: string, head = 6, tail = 6): string {
+  if (!hash) return "—";
+  if (hash.length <= head + tail + 1) return hash;
+  return `${hash.slice(0, head)}…${hash.slice(-tail)}`;
+}
+
+/**
+ * Truncate a Stellar-style wallet address (e.g. `GBVBK…QBXP`).
+ */
+function truncateAddress(address?: string, head = 6, tail = 4): string {
+  if (!address) return "—";
+  if (address.length <= head + tail + 1) return address;
+  return `${address.slice(0, head)}…${address.slice(-tail)}`;
+}
+
+/** Safely format an ISO date string for display. */
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+const STATUS_LABEL: Record<SearchResultStatus, string> = {
+  verified: "Verified",
+  pending: "Pending",
+  failed: "Failed",
+};
+
+const STATUS_BADGE_CLASS: Record<SearchResultStatus, string> = {
+  verified:
+    "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
+  pending:
+    "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
+  failed:
+    "bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+};
+
+const STATUS_ICON_BIG: Record<SearchResultStatus, React.ReactNode> = {
+  verified: <ShieldCheck className="w-5 h-5" aria-hidden />,
+  pending: <Loader2 className="w-5 h-5 animate-spin" aria-hidden />,
+  failed: <ShieldAlert className="w-5 h-5" aria-hidden />,
+};
+
+const STATUS_ICON_SMALL: Record<SearchResultStatus, React.ReactNode> = {
+  verified: <ShieldCheck className="w-4 h-4" aria-hidden />,
+  pending: <Loader2 className="w-4 h-4 animate-spin" aria-hidden />,
+  failed: <ShieldAlert className="w-4 h-4" aria-hidden />,
+};
+
+/* ------------------------------------------------------------------ */
+/*                       Internal sub-components                      */
+/* ------------------------------------------------------------------ */
+
+function StatusBadge({ status }: { status: SearchResultStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider",
+        STATUS_BADGE_CLASS[status],
+      )}
+      aria-label={`Status: ${STATUS_LABEL[status]}`}
+    >
+      {STATUS_ICON_SMALL[status]}
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+/**
+ * Inline copy button. Renders outside the `<Link>` element of the row
+ * (stretched-link pattern), so it does not nest interactive content
+ * inside an anchor.
+ */
+function CopyButton({ value, label }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!value) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // Clipboard API unavailable.
+      }
+    },
+    [value],
+  );
+
+  if (!value) {
+    return (
+      <span
+        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-gray-300 dark:text-gray-600 cursor-not-allowed"
+        aria-label="No hash to copy"
+      >
+        <Copy className="w-3.5 h-3.5" aria-hidden />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={
+        copied
+          ? `${label ?? "Hash"} copied`
+          : `Copy ${label ?? "hash"} to clipboard`
+      }
+      title={copied ? "Copied!" : "Copy hash"}
+      className={cn(
+        // Sit above the stretched-link pseudo-element so it stays clickable.
+        "relative z-10 inline-flex items-center justify-center w-7 h-7 rounded-md transition-colors",
+        "text-gray-400 dark:text-gray-500",
+        "hover:text-primary dark:hover:text-primary-light hover:bg-primary/10 dark:hover:bg-primary/20",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+      )}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {copied ? (
+          <motion.span
+            key="check"
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="inline-flex"
+          >
+            <Check className="w-3.5 h-3.5 text-green-500" aria-hidden />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="copy"
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="inline-flex"
+          >
+            <Copy className="w-3.5 h-3.5" aria-hidden />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </button>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*                            Row component                           */
+/* ------------------------------------------------------------------ */
+
+interface SearchResultRowProps {
+  result: SearchResult;
+}
+
+function SearchResultRow({ result }: SearchResultRowProps) {
+  const {
+    id,
+    name,
+    description,
+    hash,
+    creator,
+    mintedAt,
+    status,
+    network = "Stellar",
+    type,
+  } = result;
+
+  const displayTitle =
+    name?.trim() || `Certificate #${truncateHash(id, 4, 4)}`;
+
+  const certHref = `/certificate/${encodeURIComponent(id)}`;
+
+  return (
+    <motion.article
+      layout
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.25 }}
+      className={cn(
+        // `relative` + the stretched-link `::after` inside <Link> lets the
+        // entire row behave as a click-target without nesting <button> in <a>.
+        "group relative rounded-2xl border bg-white dark:bg-white/5",
+        "border-gray-200 dark:border-white/10",
+        "hover:border-primary/50 dark:hover:border-primary/40",
+        "hover:shadow-lg hover:shadow-primary/5 dark:hover:shadow-primary/10",
+        "focus-within:border-primary/60",
+        "transition-all duration-200",
+      )}
+    >
+      <div className="relative flex items-start gap-4 p-4 sm:p-5">
+        {/* Leading icon (decorative) */}
+        <div
+          className={cn(
+            "hidden sm:flex shrink-0 h-11 w-11 items-center justify-center rounded-xl",
+            "bg-gradient-to-br border",
+            status === "verified" &&
+              "from-green-500/15 to-green-500/5 border-green-500/20 text-green-600 dark:text-green-400",
+            status === "pending" &&
+              "from-yellow-500/15 to-yellow-500/5 border-yellow-500/20 text-yellow-600 dark:text-yellow-400",
+            status === "failed" &&
+              "from-red-500/15 to-red-500/5 border-red-500/20 text-red-600 dark:text-red-400",
+          )}
+          aria-hidden
+        >
+          {STATUS_ICON_BIG[status]}
+        </div>
+
+        {/* Content (fills available space) */}
+        <div className="flex-1 min-w-0 space-y-2">
+          {/* Title row: wraps the actual <Link> so the clickable target is a single <a> */}
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-white truncate max-w-full">
+              <Link
+                href={certHref}
+                aria-label={`View certificate ${displayTitle}`}
+                className={cn(
+                  // Stretched-link: a transparent ::after covers the whole
+                  // card so any click navigates, while the title remains
+                  // keyboard-focusable as a real <a>.
+                  "relative outline-none",
+                  "after:absolute after:inset-0 after:content-['']",
+                  "hover:text-primary dark:hover:text-primary-light",
+                  "focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:rounded-sm",
+                  "transition-colors",
+                )}
+              >
+                {displayTitle}
+              </Link>
+            </h3>
+            <StatusBadge status={status} />
+            {type && (
+              <span className="hidden sm:inline-flex items-center rounded-md bg-gray-100 dark:bg-white/5 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300">
+                {type}
+              </span>
+            )}
+          </div>
+
+          {/* Description (optional, single-line truncation) */}
+          {description && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {description}
+            </p>
+          )}
+
+          {/* Metadata grid */}
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 pt-1">
+            {/* Hash (with copy button outside the link) */}
+            <div className="flex items-center gap-1.5 min-w-0 max-w-full">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 shrink-0">
+                Hash
+              </span>
+              <code
+                className="font-mono text-xs text-gray-700 dark:text-gray-300 truncate"
+                title={hash || "Unavailable"}
+              >
+                {truncateHash(hash)}
+              </code>
+              <CopyButton value={hash || ""} label="hash" />
+            </div>
+
+            {/* Creator */}
+            <div className="flex items-center gap-1.5 min-w-0">
+              <User
+                className="w-3 h-3 shrink-0 text-gray-400 dark:text-gray-500"
+                aria-hidden
+              />
+              <span
+                className="font-mono text-xs text-gray-600 dark:text-gray-400 truncate"
+                title={creator}
+              >
+                {truncateAddress(creator)}
+              </span>
+            </div>
+
+            {/* Date */}
+            <div className="flex items-center gap-1.5">
+              <Clock
+                className="w-3 h-3 shrink-0 text-gray-400 dark:text-gray-500"
+                aria-hidden
+              />
+              <time
+                dateTime={mintedAt}
+                className="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap"
+              >
+                {formatDate(mintedAt)}
+              </time>
+            </div>
+
+            {/* Network (hidden on mobile) */}
+            <span className="hidden sm:inline-flex items-center text-[10px] font-semibold uppercase tracking-wider text-primary/80 dark:text-primary-light ml-auto">
+              {network}
+            </span>
+          </div>
+        </div>
+
+        {/* Trailing action — visible affordance for desktop users. */}
+        <span
+          className={cn(
+            "hidden sm:inline-flex shrink-0 items-center gap-1 self-center px-3 py-1.5 rounded-lg text-[11px] font-semibold",
+            "text-gray-500 dark:text-gray-400",
+            "bg-gray-50 dark:bg-white/5",
+            "group-hover:text-primary group-hover:bg-primary/10 dark:group-hover:bg-primary/20",
+            "transition-colors",
+          )}
+        >
+          View
+          <ChevronRight
+            className="w-3 h-3 group-hover:translate-x-0.5 transition-transform"
+            aria-hidden
+          />
+        </span>
+      </div>
+
+      {/* Mobile-only affordance label */}
+      <div className="sm:hidden px-4 pb-3 -mt-1 flex items-center justify-end gap-1 text-[11px] font-semibold text-primary">
+        <span>Open certificate</span>
+        <ChevronRight className="w-3.5 h-3.5" aria-hidden />
+      </div>
+    </motion.article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*                       Empty / loading states                        */
+/* ------------------------------------------------------------------ */
+
+function ListViewSkeleton({ rows = 6 }: { rows?: number }) {
+  return (
+    <ul
+      className="space-y-3"
+      role="list"
+      aria-busy="true"
+      aria-label="Loading search results"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <li
+          key={i}
+          className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 p-4 sm:p-5"
+        >
+          <div className="flex items-start gap-4">
+            <Skeleton className="hidden sm:block h-11 w-11 rounded-xl shrink-0" />
+            <div className="flex-1 min-w-0 space-y-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-4 w-16 rounded-full" />
+              </div>
+              <div className="flex items-center gap-3 pt-1">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 px-6 text-center",
+        "rounded-2xl border-2 border-dashed",
+        "border-gray-200 dark:border-white/10",
+        "bg-gray-50/50 dark:bg-white/[0.02]",
+      )}
+      role="status"
+    >
+      <div className="w-14 h-14 rounded-2xl bg-gray-100 dark:bg-white/5 flex items-center justify-center mb-4">
+        <Search className="w-6 h-6 text-gray-400" aria-hidden />
+      </div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+        Nothing to show
+      </h3>
+      <p className="text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+        {message}
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*                             Component                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * `ListView` — global certificate search results, list orientation.
+ *
+ * Renders one row per `SearchResult` with key metadata (hash, creator,
+ * date, status). Each row uses a stretched-link pattern, so the title
+ * is the actual `<a>` element while clicks anywhere on the card
+ * navigate to `/certificate/[id]`. Designed for full keyboard /
+ * screen-reader accessibility and responsive layout across mobile,
+ * tablet and desktop breakpoints.
+ */
+export function ListView({
+  results,
+  isLoading = false,
+  emptyMessage = "No certificates match your search.",
+  onLoadMore,
+  hasMore = false,
+}: ListViewProps) {
+  if (isLoading) {
+    return <ListViewSkeleton />;
+  }
+
+  if (results.length === 0) {
+    return <EmptyState message={emptyMessage} />;
+  }
+
+  return (
+    <section aria-label="Search results" className="space-y-3">
+      <ul role="list" className="space-y-3">
+        <AnimatePresence mode="popLayout" initial={false}>
+          {results.map((result, index) => (
+            <motion.li
+              key={result.id}
+              layout
+              initial={{ opacity: 0, y: 12 }}
+              animate={{
+                opacity: 1,
+                y: 0,
+                transition: { delay: Math.min(index * 0.04, 0.4) },
+              }}
+              exit={{ opacity: 0, y: -8 }}
+            >
+              <SearchResultRow result={result} />
+            </motion.li>
+          ))}
+        </AnimatePresence>
+      </ul>
+
+      {hasMore && onLoadMore && (
+        <div className="flex justify-center pt-2">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className={cn(
+              "inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium",
+              "border border-gray-300 dark:border-white/10",
+              "bg-white dark:bg-white/5",
+              "text-gray-700 dark:text-gray-300",
+              "hover:border-primary dark:hover:border-primary",
+              "hover:text-primary dark:hover:text-primary-light",
+              "transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+            )}
+          >
+            Load more results
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default ListView;

--- a/frontend/app/search/components/ListView.tsx
+++ b/frontend/app/search/components/ListView.tsx
@@ -1,22 +1,24 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  ShieldCheck,
-  ShieldAlert,
-  Loader2,
-  Copy,
-  Check,
-  Search,
   Clock,
   User,
   ChevronRight,
 } from "lucide-react";
 import { cn } from "../../../utils/cn";
 import { Skeleton } from "../../../components/ui/Skeleton";
-import type { SearchResult, SearchResultStatus } from "../types";
+import type { SearchResult } from "../types";
+import {
+  truncateHash,
+  truncateAddress,
+  formatDate,
+  STATUS_ICON_BIG,
+  StatusBadge,
+  CopyButton,
+  EmptyState,
+} from "./shared";
 
 /* ------------------------------------------------------------------ */
 /*                              Types                                 */
@@ -33,171 +35,6 @@ export interface ListViewProps {
   onLoadMore?: () => void;
   /** Whether more results are available (shows "Load more" affordance). */
   hasMore?: boolean;
-}
-
-/* ------------------------------------------------------------------ */
-/*                              Helpers                               */
-/* ------------------------------------------------------------------ */
-
-/**
- * Middle-truncate a hash so the full hash remains inspectable while
- * keeping the list row compact (e.g. `0x1a2b…f0e1`).
- */
-function truncateHash(hash?: string, head = 6, tail = 6): string {
-  if (!hash) return "—";
-  if (hash.length <= head + tail + 1) return hash;
-  return `${hash.slice(0, head)}…${hash.slice(-tail)}`;
-}
-
-/**
- * Truncate a Stellar-style wallet address (e.g. `GBVBK…QBXP`).
- */
-function truncateAddress(address?: string, head = 6, tail = 4): string {
-  if (!address) return "—";
-  if (address.length <= head + tail + 1) return address;
-  return `${address.slice(0, head)}…${address.slice(-tail)}`;
-}
-
-/** Safely format an ISO date string for display. */
-function formatDate(iso?: string): string {
-  if (!iso) return "—";
-  try {
-    return new Date(iso).toLocaleString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return iso;
-  }
-}
-
-const STATUS_LABEL: Record<SearchResultStatus, string> = {
-  verified: "Verified",
-  pending: "Pending",
-  failed: "Failed",
-};
-
-const STATUS_BADGE_CLASS: Record<SearchResultStatus, string> = {
-  verified:
-    "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
-  pending:
-    "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
-  failed:
-    "bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
-};
-
-const STATUS_ICON_BIG: Record<SearchResultStatus, React.ReactNode> = {
-  verified: <ShieldCheck className="w-5 h-5" aria-hidden />,
-  pending: <Loader2 className="w-5 h-5 animate-spin" aria-hidden />,
-  failed: <ShieldAlert className="w-5 h-5" aria-hidden />,
-};
-
-const STATUS_ICON_SMALL: Record<SearchResultStatus, React.ReactNode> = {
-  verified: <ShieldCheck className="w-4 h-4" aria-hidden />,
-  pending: <Loader2 className="w-4 h-4 animate-spin" aria-hidden />,
-  failed: <ShieldAlert className="w-4 h-4" aria-hidden />,
-};
-
-/* ------------------------------------------------------------------ */
-/*                       Internal sub-components                      */
-/* ------------------------------------------------------------------ */
-
-function StatusBadge({ status }: { status: SearchResultStatus }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider",
-        STATUS_BADGE_CLASS[status],
-      )}
-      aria-label={`Status: ${STATUS_LABEL[status]}`}
-    >
-      {STATUS_ICON_SMALL[status]}
-      {STATUS_LABEL[status]}
-    </span>
-  );
-}
-
-/**
- * Inline copy button. Renders outside the `<Link>` element of the row
- * (stretched-link pattern), so it does not nest interactive content
- * inside an anchor.
- */
-function CopyButton({ value, label }: { value: string; label?: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(
-    async (event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (!value) return;
-      try {
-        await navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      } catch {
-        // Clipboard API unavailable.
-      }
-    },
-    [value],
-  );
-
-  if (!value) {
-    return (
-      <span
-        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-gray-300 dark:text-gray-600 cursor-not-allowed"
-        aria-label="No hash to copy"
-      >
-        <Copy className="w-3.5 h-3.5" aria-hidden />
-      </span>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label={
-        copied
-          ? `${label ?? "Hash"} copied`
-          : `Copy ${label ?? "hash"} to clipboard`
-      }
-      title={copied ? "Copied!" : "Copy hash"}
-      className={cn(
-        // Sit above the stretched-link pseudo-element so it stays clickable.
-        "relative z-10 inline-flex items-center justify-center w-7 h-7 rounded-md transition-colors",
-        "text-gray-400 dark:text-gray-500",
-        "hover:text-primary dark:hover:text-primary-light hover:bg-primary/10 dark:hover:bg-primary/20",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-      )}
-    >
-      <AnimatePresence mode="wait" initial={false}>
-        {copied ? (
-          <motion.span
-            key="check"
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.8, opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            className="inline-flex"
-          >
-            <Check className="w-3.5 h-3.5 text-green-500" aria-hidden />
-          </motion.span>
-        ) : (
-          <motion.span
-            key="copy"
-            initial={{ scale: 0.8, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.8, opacity: 0 }}
-            transition={{ duration: 0.15 }}
-            className="inline-flex"
-          >
-            <Copy className="w-3.5 h-3.5" aria-hidden />
-          </motion.span>
-        )}
-      </AnimatePresence>
-    </button>
-  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -378,7 +215,7 @@ function SearchResultRow({ result }: SearchResultRowProps) {
 }
 
 /* ------------------------------------------------------------------ */
-/*                       Empty / loading states                        */
+/*                       Loading skeleton                             */
 /* ------------------------------------------------------------------ */
 
 function ListViewSkeleton({ rows = 6 }: { rows?: number }) {
@@ -411,30 +248,6 @@ function ListViewSkeleton({ rows = 6 }: { rows?: number }) {
         </li>
       ))}
     </ul>
-  );
-}
-
-function EmptyState({ message }: { message: string }) {
-  return (
-    <div
-      className={cn(
-        "flex flex-col items-center justify-center py-16 px-6 text-center",
-        "rounded-2xl border-2 border-dashed",
-        "border-gray-200 dark:border-white/10",
-        "bg-gray-50/50 dark:bg-white/[0.02]",
-      )}
-      role="status"
-    >
-      <div className="w-14 h-14 rounded-2xl bg-gray-100 dark:bg-white/5 flex items-center justify-center mb-4">
-        <Search className="w-6 h-6 text-gray-400" aria-hidden />
-      </div>
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
-        Nothing to show
-      </h3>
-      <p className="text-xs text-gray-500 dark:text-gray-400 max-w-xs">
-        {message}
-      </p>
-    </div>
   );
 }
 

--- a/frontend/app/search/components/shared.tsx
+++ b/frontend/app/search/components/shared.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ShieldCheck,
+  ShieldAlert,
+  Loader2,
+  Copy,
+  Check,
+  Search,
+} from "lucide-react";
+import { cn } from "../../../utils/cn";
+import type { SearchResultStatus } from "../types";
+
+/* ------------------------------------------------------------------ */
+/*                          Hash / Date helpers                       */
+/* ------------------------------------------------------------------ */
+
+/** Middle-truncate a hash for compact display (e.g. `0x1a2b…f0e1`). */
+export function truncateHash(hash?: string, head = 6, tail = 6): string {
+  if (!hash) return "—";
+  if (hash.length <= head + tail + 1) return hash;
+  return `${hash.slice(0, head)}…${hash.slice(-tail)}`;
+}
+
+/** Truncate a Stellar-style wallet address (e.g. `GBVBK…QBXP`). */
+export function truncateAddress(
+  address?: string,
+  head = 6,
+  tail = 4,
+): string {
+  if (!address) return "—";
+  if (address.length <= head + tail + 1) return address;
+  return `${address.slice(0, head)}…${address.slice(-tail)}`;
+}
+
+/** Safely format an ISO date string for display. */
+export function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*                            Constants                               */
+/* ------------------------------------------------------------------ */
+
+export const STATUS_LABEL: Record<SearchResultStatus, string> = {
+  verified: "Verified",
+  pending: "Pending",
+  failed: "Failed",
+};
+
+export const STATUS_BADGE_CLASS: Record<SearchResultStatus, string> = {
+  verified:
+    "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800",
+  pending:
+    "bg-yellow-50 text-yellow-700 border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-800",
+  failed:
+    "bg-red-50 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800",
+};
+
+export const STATUS_ICON_BIG: Record<SearchResultStatus, React.ReactNode> = {
+  verified: <ShieldCheck className="w-5 h-5" aria-hidden />,
+  pending: <Loader2 className="w-5 h-5 animate-spin" aria-hidden />,
+  failed: <ShieldAlert className="w-5 h-5" aria-hidden />,
+};
+
+export const STATUS_ICON_SMALL: Record<SearchResultStatus, React.ReactNode> = {
+  verified: <ShieldCheck className="w-4 h-4" aria-hidden />,
+  pending: <Loader2 className="w-4 h-4 animate-spin" aria-hidden />,
+  failed: <ShieldAlert className="w-4 h-4" aria-hidden />,
+};
+
+/* ------------------------------------------------------------------ */
+/*                        Shared components                           */
+/* ------------------------------------------------------------------ */
+
+export function StatusBadge({ status }: { status: SearchResultStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider",
+        STATUS_BADGE_CLASS[status],
+      )}
+      aria-label={`Status: ${STATUS_LABEL[status]}`}
+    >
+      {STATUS_ICON_SMALL[status]}
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+export function CopyButton({
+  value,
+  label,
+}: {
+  value: string;
+  label?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (
+      event:
+        | React.MouseEvent<HTMLButtonElement>
+        | React.KeyboardEvent,
+    ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!value) return;
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // Clipboard API unavailable.
+      }
+    },
+    [value],
+  );
+
+  if (!value) {
+    return (
+      <span
+        className="inline-flex items-center justify-center w-7 h-7 rounded-md text-gray-300 dark:text-gray-600 cursor-not-allowed"
+        aria-label="No hash to copy"
+      >
+        <Copy className="w-3.5 h-3.5" aria-hidden />
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={
+        copied
+          ? `${label ?? "Hash"} copied`
+          : `Copy ${label ?? "hash"} to clipboard`
+      }
+      title={copied ? "Copied!" : "Copy hash"}
+      className={cn(
+        "relative z-10 inline-flex items-center justify-center w-7 h-7 rounded-md transition-colors",
+        "text-gray-400 dark:text-gray-500",
+        "hover:text-primary dark:hover:text-primary-light hover:bg-primary/10 dark:hover:bg-primary/20",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+      )}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {copied ? (
+          <motion.span
+            key="check"
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="inline-flex"
+          >
+            <Check className="w-3.5 h-3.5 text-green-500" aria-hidden />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="copy"
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="inline-flex"
+          >
+            <Copy className="w-3.5 h-3.5" aria-hidden />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </button>
+  );
+}
+
+export function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 px-6 text-center",
+        "rounded-2xl border-2 border-dashed",
+        "border-gray-200 dark:border-white/10",
+        "bg-gray-50/50 dark:bg-white/[0.02]",
+      )}
+      role="status"
+    >
+      <div className="w-14 h-14 rounded-2xl bg-gray-100 dark:bg-white/5 flex items-center justify-center mb-4">
+        <Search className="w-6 h-6 text-gray-400" aria-hidden />
+      </div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+        Nothing to show
+      </h3>
+      <p className="text-xs text-gray-500 dark:text-gray-400 max-w-xs">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -8,6 +8,7 @@ import {
   ShieldCheck,
   AlertCircle,
   List,
+  LayoutGrid,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import Header from "../../components/Header";
@@ -16,8 +17,24 @@ import {
   searchCertificates,
 } from "./services/searchService";
 import { ListView } from "./components/ListView";
+import { GridView } from "./components/GridView";
 import type { SearchResult } from "./types";
 import { cn } from "../../utils/cn";
+
+type ViewMode = "list" | "grid";
+
+const VIEW_STORAGE_KEY = "searchViewPreference";
+
+function readViewPreference(): ViewMode {
+  if (typeof window === "undefined") return "list";
+  try {
+    const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
+    if (stored === "list" || stored === "grid") return stored;
+  } catch {
+    // localStorage unavailable (e.g. privacy mode).
+  }
+  return "list";
+}
 
 /**
  * Debounce delay between keystrokes and the actual search call (ms).
@@ -27,8 +44,9 @@ const SEARCH_DEBOUNCE_MS = 300;
 /**
  * Global Certificate Search page.
  *
- * Displays a list of verified or pending certificates indexed across
- * the StellarProof network. Includes a search input, status summary,
+ * Displays a list or grid of verified or pending certificates indexed
+ * across the StellarProof network. Includes a search input, status
+ * summary, view toggle (list/grid) with localStorage persistence,
  * and zero / loading states.
  */
 export default function SearchPage() {
@@ -42,6 +60,8 @@ export default function SearchPage() {
   // Start in loading state so the first paint shows the skeleton.
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  /** View mode (list vs grid), initialised from localStorage. */
+  const [viewMode, setViewMode] = useState<ViewMode>(readViewPreference);
 
   /* ---------------------------------------------------------------- */
   /*              Initial dataset load on mount                      */
@@ -70,6 +90,17 @@ export default function SearchPage() {
       cancelled = true;
     };
   }, []);
+
+  /* ---------------------------------------------------------------- */
+  /*          Persist view preference to localStorage                */
+  /* ---------------------------------------------------------------- */
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+    } catch {
+      // localStorage unavailable.
+    }
+  }, [viewMode]);
 
   /* ---------------------------------------------------------------- */
   /*              Debounced search on query change                   */
@@ -164,10 +195,44 @@ export default function SearchPage() {
                 ? "Loading…"
                 : `${totalCount} total result${totalCount === 1 ? "" : "s"}`}
             </span>
-            <span className="ml-auto inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-primary">
-              <List className="w-3.5 h-3.5" aria-hidden />
-              List view
-            </span>
+
+            {/* ── View toggle button group ──────────────────────────── */}
+            <div
+              className="ml-auto inline-flex items-center rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 p-0.5"
+              role="radiogroup"
+              aria-label="View mode"
+            >
+              <button
+                role="radio"
+                aria-checked={viewMode === "list"}
+                aria-label="List view"
+                onClick={() => setViewMode("list")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-all duration-200",
+                  viewMode === "list"
+                    ? "bg-primary/10 text-primary shadow-sm"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300",
+                )}
+              >
+                <List className="w-3.5 h-3.5" aria-hidden />
+                <span className="hidden sm:inline">List</span>
+              </button>
+              <button
+                role="radio"
+                aria-checked={viewMode === "grid"}
+                aria-label="Grid view"
+                onClick={() => setViewMode("grid")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold transition-all duration-200",
+                  viewMode === "grid"
+                    ? "bg-primary/10 text-primary shadow-sm"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300",
+                )}
+              >
+                <LayoutGrid className="w-3.5 h-3.5" aria-hidden />
+                <span className="hidden sm:inline">Grid</span>
+              </button>
+            </div>
           </div>
         </div>
 
@@ -225,16 +290,28 @@ export default function SearchPage() {
           </div>
         )}
 
-        {/* ─── Results list view ────────────────────────────────────── */}
-        <ListView
-          results={results}
-          isLoading={loading}
-          emptyMessage={
-            query.trim()
-              ? `No certificates match "${query.trim()}"`
-              : "No certificates have been indexed yet."
-          }
-        />
+        {/* ─── Results view (list or grid) ──────────────────────────── */}
+        {viewMode === "list" ? (
+          <ListView
+            results={results}
+            isLoading={loading}
+            emptyMessage={
+              query.trim()
+                ? `No certificates match "${query.trim()}"`
+                : "No certificates have been indexed yet."
+            }
+          />
+        ) : (
+          <GridView
+            results={results}
+            isLoading={loading}
+            emptyMessage={
+              query.trim()
+                ? `No certificates match "${query.trim()}"`
+                : "No certificates have been indexed yet."
+            }
+          />
+        )}
       </main>
     </div>
   );

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import {
+  Search,
+  X,
+  Globe,
+  ShieldCheck,
+  AlertCircle,
+  List,
+} from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import Header from "../../components/Header";
+import {
+  fetchAllCertificates,
+  searchCertificates,
+} from "./services/searchService";
+import { ListView } from "./components/ListView";
+import type { SearchResult } from "./types";
+import { cn } from "../../utils/cn";
+
+/**
+ * Debounce delay between keystrokes and the actual search call (ms).
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Global Certificate Search page.
+ *
+ * Displays a list of verified or pending certificates indexed across
+ * the StellarProof network. Includes a search input, status summary,
+ * and zero / loading states.
+ */
+export default function SearchPage() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  /**
+   * Snapshot of the full backend response, restored when the user clears
+   * the search input. Avoids a redundant network round-trip once cached.
+   */
+  const [allResults, setAllResults] = useState<SearchResult[]>([]);
+  // Start in loading state so the first paint shows the skeleton.
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  /* ---------------------------------------------------------------- */
+  /*              Initial dataset load on mount                      */
+  /* ---------------------------------------------------------------- */
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchAllCertificates()
+      .then((data) => {
+        if (cancelled) return;
+        setAllResults(data);
+        setResults(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError(
+            "Failed to load global certificate index. Please try again.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /* ---------------------------------------------------------------- */
+  /*              Debounced search on query change                   */
+  /* ---------------------------------------------------------------- */
+  // The empty-query case is intentionally NOT handled here — it is
+  // managed by `handleQueryChange` (an event handler) so that we do not
+  // dispatch synchronous setState calls inside an effect body.
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed === "") return;
+
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      searchCertificates(trimmed)
+        .then((data) => {
+          if (!cancelled) setResults(data);
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setError("Search failed. Please try again.");
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [query]);
+
+  function handleQueryChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const next = event.target.value;
+    setError(null);
+    setQuery(next);
+
+    const trimmed = next.trim();
+
+    // Clearing the search: restore cached full dataset without a spinner.
+    if (trimmed === "") {
+      if (allResults.length > 0) {
+        setResults(allResults);
+      }
+      // Always clear loading on the empty path so the skeleton does not
+      // remain stale after a type→clear sequence.
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+  }
+
+  const verifiedCount = results.filter((r) => r.status === "verified").length;
+  const totalCount = results.length;
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-[#020617] font-sans">
+      <Header />
+
+      <main
+        id="main-content"
+        className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 sm:py-12"
+      >
+        {/* ─── Page header ───────────────────────────────────────────── */}
+        <div className="mb-8 sm:mb-10">
+          <div className="flex items-center gap-2 mb-3">
+            <div className="flex h-10 w-10 sm:h-11 sm:w-11 items-center justify-center rounded-xl bg-primary/10 border border-primary/20">
+              <Globe className="w-5 h-5 text-primary" aria-hidden />
+            </div>
+            <div>
+              <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-gray-900 dark:text-white">
+                Global Certificate Search
+              </h1>
+              <p className="mt-1 text-xs sm:text-sm text-gray-500 dark:text-gray-400 max-w-2xl">
+                Public index of verifiable certificates issued on the
+                StellarProof network. Every record is anchored on-chain and
+                tamper-evident.
+              </p>
+            </div>
+          </div>
+
+          {/* Stats bar */}
+          <div className="flex flex-wrap items-center gap-3 mt-5">
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800">
+              <ShieldCheck className="w-3.5 h-3.5" aria-hidden />
+              {loading ? "…" : `${verifiedCount} verified`}
+            </span>
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-white/10">
+              {loading
+                ? "Loading…"
+                : `${totalCount} total result${totalCount === 1 ? "" : "s"}`}
+            </span>
+            <span className="ml-auto inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wider text-primary">
+              <List className="w-3.5 h-3.5" aria-hidden />
+              List view
+            </span>
+          </div>
+        </div>
+
+        {/* ─── Search input ──────────────────────────────────────────── */}
+        <div className="relative mb-6 sm:mb-8 max-w-2xl">
+          <Search
+            className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-gray-500"
+            aria-hidden
+          />
+          <input
+            type="search"
+            aria-label="Search certificates globally"
+            placeholder="Search by certificate id, asset name, creator or hash…"
+            value={query}
+            onChange={handleQueryChange}
+            className={cn(
+              "w-full rounded-xl border border-gray-300 dark:border-white/10",
+              "bg-white dark:bg-white/5 py-2.5 sm:py-3 pl-10 pr-10",
+              "text-sm sm:text-base text-gray-900 dark:text-white",
+              "placeholder:text-gray-400 dark:placeholder:text-gray-500",
+              "focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30",
+              "transition",
+            )}
+          />
+          <AnimatePresence>
+            {query && (
+              <motion.button
+                type="button"
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+                title="Clear search"
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 inline-flex items-center justify-center w-7 h-7 rounded-md text-gray-400 dark:text-gray-500 hover:text-primary dark:hover:text-primary-light hover:bg-primary/10 dark:hover:bg-primary/20 transition-colors"
+              >
+                <X className="w-4 h-4" aria-hidden />
+              </motion.button>
+            )}
+          </AnimatePresence>
+        </div>
+
+        {/* ─── Error state ───────────────────────────────────────────── */}
+        {error && (
+          <div className="mb-6 flex items-start gap-3 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4">
+            <AlertCircle
+              className="w-5 h-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5"
+              aria-hidden
+            />
+            <div>
+              <p className="text-sm font-medium text-red-700 dark:text-red-300">
+                {error}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ─── Results list view ────────────────────────────────────── */}
+        <ListView
+          results={results}
+          isLoading={loading}
+          emptyMessage={
+            query.trim()
+              ? `No certificates match "${query.trim()}"`
+              : "No certificates have been indexed yet."
+          }
+        />
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/search/services/searchService.ts
+++ b/frontend/app/search/services/searchService.ts
@@ -1,0 +1,116 @@
+import type { SearchResult } from "../types";
+
+/**
+ * Mock dataset used by the Global Certificate Search results UI while the
+ * on-chain indexer is under development. Replace `searchCertificates()` with
+ * a live oracle / indexer call once the registry backend is wired up.
+ */
+const MOCK_RESULTS: SearchResult[] = [
+  {
+    id: "cert-aurora-001",
+    name: "Aurora — Limited Edition Album",
+    description: "Limited release album with full ownership verified on-chain.",
+    hash: "0xa1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+    creator: "GBVBK2TX7QHEQNIMUPBVPZ7EONL52TWKQ7OXFDJPAJPYGNZFACUQBXP",
+    mintedAt: "2025-01-12T10:42:00Z",
+    status: "verified",
+    type: "Audio",
+  },
+  {
+    id: "cert-3d-print-002",
+    name: "Industrial 3D Print STL Pack",
+    description: "STL files for 3D printing with authenticity verified on blockchain.",
+    hash: "0xb2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1",
+    creator: "GABXFFYHSZOGVKCW3YSXAOZZKFN5HGCMRHSNKGZLPM3KCRQZZFU2XJNC",
+    mintedAt: "2025-02-04T18:15:00Z",
+    status: "verified",
+    type: "3D Model",
+  },
+  {
+    id: "cert-painting-003",
+    name: "Genesis — Original Painting",
+    description: "Original physical artwork with on-chain provenance record.",
+    hash: "0xc3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2",
+    creator: "GDQP2KPQGKIHYMV727FKZ5XZ7Y7Q3O3F2K3Z3JJQNZQFCK4LVNXJKJLE",
+    mintedAt: "2025-02-21T12:00:00Z",
+    status: "pending",
+    type: "Image",
+  },
+  {
+    id: "cert-text-004",
+    name: "Independent Journalism Report",
+    description: "Long-form investigative article with cryptographic fingerprint.",
+    hash: "0xd4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3",
+    creator: "GCXFGHG4FOEZHK4YQYHZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQX",
+    mintedAt: "2024-12-30T09:30:00Z",
+    status: "verified",
+    type: "Document",
+  },
+  {
+    id: "cert-audio-005",
+    name: "Field Recording — Mountain Pass",
+    description: "High-fidelity nature recording with IPFS-backed proof.",
+    hash: "0xe5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4",
+    creator: "GCNZG3VQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJG",
+    mintedAt: "2025-03-02T07:10:00Z",
+    status: "verified",
+    type: "Audio",
+  },
+  {
+    id: "cert-photo-006",
+    name: "Wedding Photography Series",
+    description: "Photo set with creator signature certificate.",
+    hash: "",
+    creator: "GDFFGHG4FOEZHK4YQYHZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQX",
+    mintedAt: "2025-03-15T22:00:00Z",
+    status: "failed",
+    type: "Image",
+  },
+  {
+    id: "cert-video-007",
+    name: "Short Film — Northern Lights",
+    description: "Award-winning short film, content hash anchored on Stellar.",
+    hash: "0xf6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5",
+    creator: "GBQQXGCM3XKZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJGZQXJ",
+    mintedAt: "2025-03-25T15:45:00Z",
+    status: "verified",
+    type: "Video",
+  },
+];
+
+/**
+ * Simulated network delay (ms) used while the real indexer is offline.
+ */
+const MOCK_LATENCY_MS = 600;
+
+/**
+ * Returns the full mock dataset. Will be replaced by a backend indexer call.
+ */
+export async function fetchAllCertificates(): Promise<SearchResult[]> {
+  await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
+  return MOCK_RESULTS;
+}
+
+/**
+ * Mock search across the certificate index. Performs a case-insensitive
+ * match against id, name, description, creator and hash. Returns an
+ * empty array when no rows match.
+ */
+export async function searchCertificates(
+  query: string,
+): Promise<SearchResult[]> {
+  await new Promise((resolve) => setTimeout(resolve, MOCK_LATENCY_MS));
+
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return MOCK_RESULTS;
+
+  return MOCK_RESULTS.filter((item) => {
+    return (
+      item.id.toLowerCase().includes(trimmed) ||
+      (item.name?.toLowerCase().includes(trimmed) ?? false) ||
+      (item.description?.toLowerCase().includes(trimmed) ?? false) ||
+      item.creator.toLowerCase().includes(trimmed) ||
+      item.hash.toLowerCase().includes(trimmed)
+    );
+  });
+}

--- a/frontend/app/search/types.ts
+++ b/frontend/app/search/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Domain types for the Global Certificate Search feature.
+ *
+ * A `SearchResult` represents a verified-or-pending certification record that
+ * can be returned from a global search query across the StellarProof network.
+ * It is the flatter, list-focused projection of an on-chain
+ * `ProvenanceCertificate` suitable for rendering in list views.
+ */
+
+export type SearchResultStatus = "verified" | "pending" | "failed";
+
+export interface SearchResult {
+  /** Unique certificate / asset id (used to navigate to `/certificate/[id]`). */
+  id: string;
+
+  /** Human-readable asset name; falls back to a generic label when absent. */
+  name?: string;
+
+  /** Short, optional summary describing the asset. */
+  description?: string;
+
+  /** Primary hash to display (e.g. content hash). May be empty for failed mints. */
+  hash: string;
+
+  /** Creator / owner wallet address. Stellar accounts start with `G`. */
+  creator: string;
+
+  /** ISO 8601 timestamp string for when the asset was minted. */
+  mintedAt: string;
+
+  /** Verification status of the asset. */
+  status: SearchResultStatus;
+
+  /** Underlying network name (defaults to "Stellar" when omitted). */
+  network?: string;
+
+  /** Optional category / tag, e.g. "Image", "Document", "Audio". */
+  type?: string;
+}


### PR DESCRIPTION
## Summary

Adds a UI toggle button group to switch between List and Grid views on the search results page. Includes localStorage persistence so the user's preference is remembered across page reloads.

Closes #376

## Affected Path

`frontend/app/search/page.tsx` — view toggle + localStorage persistence

## New Files

| Path | Purpose |
|---|---|
| `frontend/app/search/components/GridView.tsx` | Card grid view (1/2/3 cols responsive) with stretched-link pattern |
| `frontend/app/search/components/shared.tsx` | Shared helpers (truncateHash, truncateAddress, formatDate), constants, StatusBadge, CopyButton, EmptyState |

## Modified Files

| Path | Change |
|---|---|
| `frontend/app/search/components/ListView.tsx` | Refactored to import shared utilities from `./shared` |
| `frontend/app/search/page.tsx` | Added view toggle radiogroup, ViewMode state, localStorage persist |

## Acceptance Criteria

- ✅ Clicking List/Grid toggle switches views instantly with animated transitions
- ✅ Preference is saved to `localStorage` (key: `searchViewPreference`) and restored on reload
- ✅ Grid view: responsive 1/2/3 column layout, cards with status icon, title, description, hash, creator, date, network
- ✅ Accessible toggle: `role="radiogroup"` with `aria-checked`
- ✅ All CI passes: tsc --noEmit exits 0, lint exits 0, next build produces /search route

## Technical Notes

- **ViewMode** typed as `"list" | "grid"`, initialized from localStorage via `readViewPreference()`
- **localStorage persistence** handled in a dedicated `useEffect` that writes on every `viewMode` change
- **Code deduplication** — StatusBadge, CopyButton, EmptyState, and helper functions extracted to `shared.tsx` to avoid duplication between ListView and GridView
- **Stretched-link pattern** consistent across both views: title is the clickable `<a>` with `after:absolute after:inset-0`

## CI

| Step | Status |
|---|---|
| `tsc --noEmit` | ✅ 0 errors |
| `pnpm run lint` | ✅ 0 errors |
| `pnpm run build` | ✅ /search route registered |