### PR TITLE
Integrate Freighter wallet signing into verification submission

### DIFF
--- a/frontend/app/dashboard/assets/components/AssetGrid.tsx
+++ b/frontend/app/dashboard/assets/components/AssetGrid.tsx
@@ -248,23 +248,18 @@ interface AssetGridProps {
 }
 
 export default function AssetGrid({ assets }: AssetGridProps) {
-  const [items, setItems] = useState<Asset[] | null>(assets ?? null);
+  const [mockItems, setMockItems] = useState<Asset[] | null>(null);
   const [isLoading, setIsLoading] = useState(!assets);
 
   useEffect(() => {
-    if (assets) {
-      setItems(assets);
-      setIsLoading(false);
-      return;
-    }
+    if (assets) return;
 
     let cancelled = false;
-    setIsLoading(true);
 
     // Simulate asset retrieval until the service layer is wired in.
     const timer = setTimeout(() => {
       if (!cancelled) {
-        setItems(MOCK_ASSETS);
+        setMockItems(MOCK_ASSETS);
         setIsLoading(false);
       }
     }, 400);
@@ -274,6 +269,8 @@ export default function AssetGrid({ assets }: AssetGridProps) {
       clearTimeout(timer);
     };
   }, [assets]);
+
+  const items = assets ?? mockItems;
 
   return (
     <section aria-label="Digital assets gallery">

--- a/frontend/features/verification/components/WizardPageShell.tsx
+++ b/frontend/features/verification/components/WizardPageShell.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { useWizardStore } from '../store/wizard.store';
+import { useWallet } from '@/context/WalletContext';
 import WizardStepper from './WizardStepper';
 import WizardNavigation from './WizardNavigation';
 import UploadMedia from './steps/UploadMedia';
@@ -27,7 +28,9 @@ export default function WizardPageShell() {
   } = useWizardStore();
 
   const hasHydrated = useWizardStore((state) => state._hasHydrated);
+  const { publicKey, isConnected, connect } = useWallet();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const isLastStep = currentStep === STEPS.length - 1;
   const isFirstStep = currentStep === 0;
@@ -52,21 +55,30 @@ export default function WizardPageShell() {
   );
 
   const handleSubmit = useCallback(async () => {
+    if (!isConnected || !publicKey) {
+      setSubmitError('Please connect your Freighter wallet before submitting.');
+      return;
+    }
+
+    setSubmitError(null);
     setIsSubmitting(true);
     try {
       const content = formData.content;
       await submitVerificationRequest(
         content?.contentHash ?? '',
         content?.manifestHash ?? null,
-        'GAAAAAAAAAAAAAAA',
+        publicKey,
       );
       resetWizard();
     } catch (error) {
       console.error('Submission failed:', error);
+      setSubmitError(
+        error instanceof Error ? error.message : 'Submission failed. Please try again.',
+      );
     } finally {
       setIsSubmitting(false);
     }
-  }, [formData.content, resetWizard]);
+  }, [formData.content, resetWizard, isConnected, publicKey]);
 
   const handleCancel = useCallback(() => {
     resetWizard();
@@ -81,6 +93,9 @@ export default function WizardPageShell() {
       onNavigate={handleNavigate}
       onSubmit={handleSubmit}
       isSubmitting={isSubmitting}
+      walletConnected={isConnected}
+      onConnectWallet={connect}
+      submitError={submitError}
     />,
   ];
 

--- a/frontend/features/verification/components/steps/UploadReview.tsx
+++ b/frontend/features/verification/components/steps/UploadReview.tsx
@@ -11,6 +11,8 @@ import {
   Send,
   Loader2,
   Upload,
+  Wallet,
+  AlertCircle,
 } from 'lucide-react';
 import { useWizardStore } from '../../store/wizard.store';
 import { isValidSHA256 } from '@/utils/crypto';
@@ -19,6 +21,9 @@ export interface UploadReviewProps {
   onNavigate?: (step: number) => void;
   onSubmit?: () => void | Promise<void>;
   isSubmitting?: boolean;
+  walletConnected?: boolean;
+  onConnectWallet?: () => void | Promise<void>;
+  submitError?: string | null;
 }
 
 function SectionHeader({
@@ -79,17 +84,36 @@ function FieldRow({
   );
 }
 
-export default function UploadReview({ onNavigate, onSubmit, isSubmitting = false }: UploadReviewProps) {
+export default function UploadReview({
+  onNavigate,
+  onSubmit,
+  isSubmitting = false,
+  walletConnected = false,
+  onConnectWallet,
+  submitError = null,
+}: UploadReviewProps) {
   const { formData } = useWizardStore();
   const content = formData.content;
   const [confirmed, setConfirmed] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
 
   const modeName = content?.encryptionEnabled ? 'SPV (Encrypted)' : 'Standard';
   const contentHashValid = isValidSHA256(content?.contentHash ?? '');
   const hasManifest = content?.manifest !== null && content?.manifest !== undefined;
 
-  const canSubmit = contentHashValid && confirmed && !isSubmitting && !submitted;
+  const canSubmit =
+    contentHashValid && confirmed && walletConnected && !isSubmitting && !submitted;
+
+  async function handleConnectWallet() {
+    if (!onConnectWallet) return;
+    setIsConnecting(true);
+    try {
+      await onConnectWallet();
+    } finally {
+      setIsConnecting(false);
+    }
+  }
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -149,6 +173,33 @@ export default function UploadReview({ onNavigate, onSubmit, isSubmitting = fals
           <p className="text-xs text-gray-400 italic">No manifest attached.</p>
         )}
       </div>
+
+      {!walletConnected && (
+        <div className="flex items-center justify-between gap-3 p-4 rounded-xl bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800">
+          <div className="flex items-start gap-2">
+            <Wallet className="w-4 h-4 mt-0.5 text-blue-600 dark:text-blue-400 shrink-0" />
+            <p className="text-xs text-blue-700 dark:text-blue-300">
+              Connect your Freighter wallet to sign and submit this verification request.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleConnectWallet}
+            disabled={isConnecting}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 text-xs font-medium text-white hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {isConnecting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wallet className="w-3.5 h-3.5" />}
+            Connect Wallet
+          </button>
+        </div>
+      )}
+
+      {submitError && (
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800">
+          <AlertCircle className="w-4 h-4 mt-0.5 text-red-600 dark:text-red-400 shrink-0" />
+          <p className="text-xs text-red-700 dark:text-red-300">{submitError}</p>
+        </div>
+      )}
 
       <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900/60 p-5 space-y-4">
         <label className="flex items-start gap-3 cursor-pointer">


### PR DESCRIPTION
## Summary

WizardPageShell submitted the final verification transaction using a hardcoded placeholder public key (`GAAAAAAAAAAAAAAA`) instead of the address of the connected Freighter wallet. `submitVerificationRequest` already builds the Soroban transaction and requests a Freighter signature, but it was always operating on a nonexistent account, so the flow could never actually succeed.

- Wire `useWallet()` from `WalletContext` into `WizardPageShell` and pass the connected wallet's real public key into `submitVerificationRequest`.
- Guard submission: if no wallet is connected, the user is prompted to connect rather than silently failing.
- `UploadReview` now shows a "Connect Wallet" affordance when disconnected, surfaces submission errors inline, and only enables the Submit button once a wallet is connected.
- Also includes a small unrelated fix to `AssetGrid.tsx` (avoids a synchronous `setState` call inside a `useEffect`) that was failing the `react-hooks/set-state-in-effect` lint rule on `main` and blocking the Lint Frontend CI step for every branch.

## Test plan

- `pnpm --filter web run lint` passes with 0 errors.
- `pnpm --filter web run build` completes successfully.
- Manually verified the submit flow requires an active wallet connection before invoking `submitVerificationRequest`.

closes #439