### PR TITLE
test(frontend): cover media file validation

### DIFF
--- a/frontend/features/verification/__tests__/media-validation.test.ts
+++ b/frontend/features/verification/__tests__/media-validation.test.ts
@@ -1,0 +1,73 @@
+import {
+  DEFAULT_MAX_MEDIA_SIZE,
+  isAcceptedMediaType,
+  validateMediaFile,
+} from "../mediaValidation";
+
+function mockFile(name: string, size: number, type: string): File {
+  const file = new File(["content"], name, { type });
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+describe("media file validation", () => {
+  it.each([
+    ["photo.png", "image/png"],
+    ["recording.mp4", "video/mp4"],
+    ["certificate.pdf", "application/pdf"],
+  ])("accepts supported file %s with type %s", (name, type) => {
+    const file = mockFile(name, 1024, type);
+
+    expect(validateMediaFile(file)).toEqual({ accepted: true, error: null });
+  });
+
+  it("accepts a file exactly at the maximum size", () => {
+    const file = mockFile("boundary.pdf", DEFAULT_MAX_MEDIA_SIZE, "application/pdf");
+
+    expect(validateMediaFile(file).accepted).toBe(true);
+  });
+
+  it("rejects a file larger than the configured maximum", () => {
+    const file = mockFile("large.png", 1025, "image/png");
+
+    expect(validateMediaFile(file, { maxSize: 1024 })).toEqual({
+      accepted: false,
+      error: "exceeds the maximum file size",
+    });
+  });
+
+  it("rejects empty files", () => {
+    const file = mockFile("empty.pdf", 0, "application/pdf");
+
+    expect(validateMediaFile(file)).toEqual({
+      accepted: false,
+      error: "is empty",
+    });
+  });
+
+  it.each([
+    ["malware.exe", "application/x-msdownload"],
+    ["notes.txt", "text/plain"],
+  ])("rejects unsupported file %s with type %s", (name, type) => {
+    const file = mockFile(name, 1024, type);
+
+    expect(validateMediaFile(file)).toEqual({
+      accepted: false,
+      error: "has an unsupported file type",
+    });
+  });
+
+  it("supports custom accepted MIME types and extensions", () => {
+    const csv = mockFile("records.csv", 1024, "text/csv");
+    const accept = { "text/csv": [".csv"] };
+
+    expect(isAcceptedMediaType(csv, accept)).toBe(true);
+    expect(validateMediaFile(csv, { accept }).accepted).toBe(true);
+  });
+
+  it("uses the extension when a browser supplies no MIME type", () => {
+    const file = mockFile("scan.JPEG", 1024, "");
+
+    expect(validateMediaFile(file).accepted).toBe(true);
+  });
+});

--- a/frontend/features/verification/components/steps/MediaUploadStep.tsx
+++ b/frontend/features/verification/components/steps/MediaUploadStep.tsx
@@ -2,6 +2,11 @@
 
 import React, { useCallback, useState, useRef, type DragEvent, type ChangeEvent } from 'react';
 import { Upload, FileImage, FileVideo, FileText, X, AlertCircle, CheckCircle2, Loader2, Eye } from 'lucide-react';
+import {
+  DEFAULT_MAX_MEDIA_SIZE,
+  DEFAULT_MEDIA_ACCEPT,
+  validateMediaFile,
+} from '../../mediaValidation';
 
 // ── Types ──────────────────────────────────────────────────
 export interface MediaFile {
@@ -32,14 +37,6 @@ export interface MediaUploadStepProps {
   hint?: string;
 }
 
-const DEFAULT_ACCEPT: Record<string, string[]> = {
-  'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.heic'],
-  'video/*': ['.mp4', '.mov', '.avi', '.webm', '.mkv'],
-  'application/pdf': ['.pdf'],
-};
-
-const DEFAULT_MAX_SIZE = 50 * 1024 * 1024; // 50 MB
-
 // ── Helpers ────────────────────────────────────────────────
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -67,8 +64,8 @@ function getFileCategory(mimeType: string): string {
 
 // ── Component ──────────────────────────────────────────────
 export default function MediaUploadStep({
-  maxSize = DEFAULT_MAX_SIZE,
-  accept = DEFAULT_ACCEPT,
+  maxSize = DEFAULT_MAX_MEDIA_SIZE,
+  accept = DEFAULT_MEDIA_ACCEPT,
   multiple = false,
   onFilesChange,
   files: externalFiles,
@@ -129,12 +126,12 @@ export default function MediaUploadStep({
       // Validate each file
       const validFiles: File[] = [];
       for (const file of incoming) {
-        if (file.size > maxSize) {
-          setError(`"${file.name}" exceeds ${formatFileSize(maxSize)} limit`);
-          continue;
-        }
-        if (file.size === 0) {
-          setError(`"${file.name}" is empty`);
+        const validation = validateMediaFile(file, { maxSize, accept });
+        if (!validation.accepted) {
+          const error = validation.error === 'exceeds the maximum file size'
+            ? `exceeds ${formatFileSize(maxSize)} limit`
+            : validation.error;
+          setError(`"${file.name}" ${error}`);
           continue;
         }
         validFiles.push(file);
@@ -171,7 +168,7 @@ export default function MediaUploadStep({
         await simulateUpload(entry.id);
       }
     },
-    [maxSize, multiple, files, setFiles, simulateUpload],
+    [maxSize, accept, multiple, files, setFiles, simulateUpload],
   );
 
 

--- a/frontend/features/verification/components/steps/__tests__/MediaUploadStep.test.tsx
+++ b/frontend/features/verification/components/steps/__tests__/MediaUploadStep.test.tsx
@@ -203,7 +203,7 @@ describe('MediaUploadStep', () => {
     });
 
     it('displays file category badge', async () => {
-      render(<MediaUploadStep />);
+      render(<MediaUploadStep accept={{ 'application/json': ['.json'] }} />);
       const file = createFile('data.json', 500, 'application/json');
       const input = screen.getByTestId('file-input');
 

--- a/frontend/features/verification/mediaValidation.ts
+++ b/frontend/features/verification/mediaValidation.ts
@@ -1,0 +1,65 @@
+export const DEFAULT_MAX_MEDIA_SIZE = 50 * 1024 * 1024;
+
+export const DEFAULT_MEDIA_ACCEPT: Record<string, string[]> = {
+  "image/*": [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".heic"],
+  "video/*": [".mp4", ".mov", ".avi", ".webm", ".mkv"],
+  "application/pdf": [".pdf"],
+};
+
+export interface MediaValidationOptions {
+  maxSize?: number;
+  accept?: Record<string, string[]>;
+}
+
+export interface MediaValidationResult {
+  accepted: boolean;
+  error: string | null;
+}
+
+function matchesMimeType(fileType: string, acceptedType: string): boolean {
+  if (acceptedType.endsWith("/*")) {
+    return fileType.startsWith(acceptedType.slice(0, -1));
+  }
+
+  return fileType === acceptedType;
+}
+
+function hasAcceptedExtension(fileName: string, extensions: string[]): boolean {
+  const normalizedName = fileName.toLowerCase();
+  return extensions.some((extension) =>
+    normalizedName.endsWith(extension.toLowerCase()),
+  );
+}
+
+export function isAcceptedMediaType(
+  file: File,
+  accept: Record<string, string[]> = DEFAULT_MEDIA_ACCEPT,
+): boolean {
+  return Object.entries(accept).some(
+    ([mimeType, extensions]) =>
+      matchesMimeType(file.type, mimeType) ||
+      hasAcceptedExtension(file.name, extensions),
+  );
+}
+
+export function validateMediaFile(
+  file: File,
+  {
+    maxSize = DEFAULT_MAX_MEDIA_SIZE,
+    accept = DEFAULT_MEDIA_ACCEPT,
+  }: MediaValidationOptions = {},
+): MediaValidationResult {
+  if (file.size === 0) {
+    return { accepted: false, error: "is empty" };
+  }
+
+  if (file.size > maxSize) {
+    return { accepted: false, error: "exceeds the maximum file size" };
+  }
+
+  if (!isAcceptedMediaType(file, accept)) {
+    return { accepted: false, error: "has an unsupported file type" };
+  }
+
+  return { accepted: true, error: null };
+}


### PR DESCRIPTION
## Description

  Closes #425

  Adds unit tests for the Media Upload file-validation logic, covering file size, MIME type, extension, and custom acceptance
  rules.

  The validation rules were extracted into a reusable helper and integrated with MediaUploadStep so the tests exercise production
  logic.

  ## Changes

  - Added reusable media file-validation utilities.
  - Enforced the existing accepted file-type configuration.
  - Added mocked File objects with varying sizes and MIME types.
  - Tested supported images, videos, and PDFs.
  - Tested files at and above the maximum-size boundary.
  - Tested empty and unsupported files.
  - Tested custom accepted types.
  - Tested extension fallback when the browser provides no MIME type.
  - Updated the existing JSON category test to explicitly allow JSON files.

  ## Testing

  - New media-validation suite: 10 passed
  - Relevant Media Upload component tests: 3 passed
  - ESLint: 0 errors
  - One pre-existing Next.js <img> optimization advisory remains.

  ## Files

  - frontend/features/verification/mediaValidation.ts
  - frontend/features/verification/__tests__/media-validation.test.ts
  - frontend/features/verification/components/steps/MediaUploadStep.tsx
  - frontend/features/verification/components/steps/__tests__/MediaUploadStep.test.tsx