### PR TITLE
test(frontend): cover verification payload builder

### DIFF
--- a/frontend/features/verification/__tests__/payload-builder.test.ts
+++ b/frontend/features/verification/__tests__/payload-builder.test.ts
@@ -1,0 +1,100 @@
+import { useWizardStore } from "../store/wizard.store";
+import type { WizardFormData } from "../types/wizard.types";
+import { buildVerificationPayload } from "../utils/payloadBuilder";
+
+const PUBLIC_KEY = `G${"A".repeat(55)}`;
+const CONTENT_HASH = "a".repeat(64);
+const MANIFEST_HASH = "b".repeat(64);
+const ENCRYPTED_HASH = "c".repeat(64);
+
+function setMockZustandData(formData: WizardFormData): WizardFormData {
+  useWizardStore.setState({ formData });
+  return useWizardStore.getState().formData;
+}
+
+describe("Review & Submit payload builder", () => {
+  afterEach(() => {
+    useWizardStore.getState().resetWizard();
+  });
+
+  it("formats Zustand wizard data to match the submission schema", () => {
+    const formData = setMockZustandData({
+      identity: { issuerAddress: PUBLIC_KEY },
+      content: {
+        file: { name: "evidence.png", size: 2048, type: "image/png" },
+        contentHash: CONTENT_HASH,
+        hashProgress: 100,
+        isHashing: false,
+        manifest: {
+          content: '{"name":"Evidence"}',
+          format: "json",
+          fileName: "manifest.json",
+          fileSize: 19,
+        },
+        manifestHash: MANIFEST_HASH,
+        encryptionEnabled: false,
+        spvResult: null,
+      },
+    });
+
+    expect(buildVerificationPayload(formData)).toEqual({
+      contentHash: CONTENT_HASH,
+      manifestHash: MANIFEST_HASH,
+      publicKey: PUBLIC_KEY,
+    });
+  });
+
+  it("uses the encrypted SPV hash when encryption is enabled", () => {
+    const formData = setMockZustandData({
+      identity: { issuerAddress: PUBLIC_KEY },
+      content: {
+        file: null,
+        contentHash: CONTENT_HASH,
+        hashProgress: 100,
+        isHashing: false,
+        manifest: null,
+        manifestHash: null,
+        encryptionEnabled: true,
+        spvResult: {
+          encryptedHash: ENCRYPTED_HASH,
+          storageId: "spv-store-123",
+        },
+      },
+    });
+
+    expect(buildVerificationPayload(formData)).toEqual({
+      contentHash: ENCRYPTED_HASH,
+      manifestHash: null,
+      publicKey: PUBLIC_KEY,
+    });
+  });
+
+  it("supports the legacy document hash and an active-wallet override", () => {
+    const formData = setMockZustandData({
+      documents: {
+        assetCode: "USDC",
+        amount: "100",
+        proofHash: CONTENT_HASH,
+      },
+    });
+
+    expect(
+      buildVerificationPayload(formData, { publicKey: `  ${PUBLIC_KEY}  ` }),
+    ).toEqual({
+      contentHash: CONTENT_HASH,
+      manifestHash: null,
+      publicKey: PUBLIC_KEY,
+    });
+  });
+
+  it("rejects incomplete Zustand data that cannot match the schema", () => {
+    const formData = setMockZustandData({});
+
+    expect(() => buildVerificationPayload(formData)).toThrow(
+      "A public key is required",
+    );
+    expect(() =>
+      buildVerificationPayload(formData, { publicKey: PUBLIC_KEY }),
+    ).toThrow("A content hash is required");
+  });
+});

--- a/frontend/features/verification/components/WizardPageShell.tsx
+++ b/frontend/features/verification/components/WizardPageShell.tsx
@@ -9,6 +9,7 @@ import UploadManifest from './steps/UploadManifest';
 import UploadSPVOptions from './steps/UploadSPVOptions';
 import UploadReview from './steps/UploadReview';
 import { submitVerificationRequest } from '@/services/verificationService';
+import { buildVerificationPayload } from '../utils/payloadBuilder';
 
 const STEPS = [
   { id: 0, label: 'Media Upload' },
@@ -54,11 +55,13 @@ export default function WizardPageShell() {
   const handleSubmit = useCallback(async () => {
     setIsSubmitting(true);
     try {
-      const content = formData.content;
+      const payload = buildVerificationPayload(formData, {
+        publicKey: 'GAAAAAAAAAAAAAAA',
+      });
       await submitVerificationRequest(
-        content?.contentHash ?? '',
-        content?.manifestHash ?? null,
-        'GAAAAAAAAAAAAAAA',
+        payload.contentHash,
+        payload.manifestHash,
+        payload.publicKey,
       );
       resetWizard();
     } catch (error) {
@@ -66,7 +69,7 @@ export default function WizardPageShell() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [formData.content, resetWizard]);
+  }, [formData, resetWizard]);
 
   const handleCancel = useCallback(() => {
     resetWizard();

--- a/frontend/features/verification/utils/payloadBuilder.ts
+++ b/frontend/features/verification/utils/payloadBuilder.ts
@@ -1,0 +1,40 @@
+import type { WizardFormData } from "../types/wizard.types";
+
+export interface VerificationSubmissionPayload {
+  contentHash: string;
+  manifestHash: string | null;
+  publicKey: string;
+}
+
+export interface PayloadBuilderOptions {
+  /** Active wallet address, used when identity data is not part of this flow. */
+  publicKey?: string;
+}
+
+export function buildVerificationPayload(
+  formData: WizardFormData,
+  options: PayloadBuilderOptions = {},
+): VerificationSubmissionPayload {
+  const content = formData.content;
+  const publicKey =
+    options.publicKey?.trim() || formData.identity?.issuerAddress.trim() || "";
+  const contentHash =
+    (content?.encryptionEnabled && content.spvResult?.encryptedHash) ||
+    content?.contentHash ||
+    formData.documents?.proofHash ||
+    "";
+
+  if (!publicKey) {
+    throw new Error("A public key is required to build the verification payload");
+  }
+
+  if (!contentHash) {
+    throw new Error("A content hash is required to build the verification payload");
+  }
+
+  return {
+    contentHash,
+    manifestHash: content?.manifestHash ?? null,
+    publicKey,
+  };
+}


### PR DESCRIPTION
 ## Description

  Closes #440

  Adds unit test coverage for the Review & Submit payload-generation logic. Zustand wizard data is now transformed through a shared
  payload builder before being passed to the verification submission service.

  ## Changes

  - Added a reusable buildVerificationPayload utility.
  - Compiles Zustand state into the required submission schema:
      - contentHash
      - manifestHash
      - publicKey

  - Uses the encrypted SPV hash when encryption is enabled.
  - Supports the legacy document proof hash.
  - Supports an active-wallet public-key override.
  - Rejects incomplete state that cannot produce a valid payload.
  - Integrated the builder into WizardPageShell.

  ## Testing

  - Payload-builder suite: 4 passed
  - ESLint: passed
  - Repository-wide TypeScript checking remains blocked by two unrelated upstream test errors:
      - Missing @/services/mockRequests
      - Invalid screen.getByAlt usage

  ## Files

  - frontend/features/verification/utils/payloadBuilder.ts
  - frontend/features/verification/__tests__/payload-builder.test.ts
  - frontend/features/verification/components/WizardPageShell.tsx