### PR TITLE
Persist media upload preview through the wizard store

### DIFF
--- a/frontend/features/verification/components/steps/UploadMedia.tsx
+++ b/frontend/features/verification/components/steps/UploadMedia.tsx
@@ -25,7 +25,10 @@ export default function UploadMedia() {
   const { formData, setUploadFile, setContentHash, setHashProgress, setIsHashing, setStepValid } = useWizardStore();
 
   const content = formData.content;
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  // The image preview lives in the store (as part of the uploaded file's
+  // metadata) so it survives step navigation instead of resetting to null
+  // whenever this component remounts.
+  const previewUrl = content?.file?.previewUrl ?? null;
   const [error, setError] = useState<string | null>(null);
 
   const handleFile = useCallback(
@@ -34,13 +37,12 @@ export default function UploadMedia() {
       setContentHash(null);
       setHashProgress(0);
 
-      let preview: string | undefined;
-      if (file.type.startsWith('image/')) {
-        preview = URL.createObjectURL(file);
-        setPreviewUrl(preview);
-      } else {
-        setPreviewUrl(null);
+      // Revoke the previous preview (if any) before creating a new one.
+      if (content?.file?.previewUrl) {
+        URL.revokeObjectURL(content.file.previewUrl);
       }
+
+      const preview = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined;
 
       setUploadFile({
         name: file.name,
@@ -62,12 +64,11 @@ export default function UploadMedia() {
         setIsHashing(false);
       }
     },
-    [setUploadFile, setContentHash, setHashProgress, setIsHashing, setStepValid],
+    [content, setUploadFile, setContentHash, setHashProgress, setIsHashing, setStepValid],
   );
 
   const handleReset = useCallback(() => {
     if (previewUrl) URL.revokeObjectURL(previewUrl);
-    setPreviewUrl(null);
     setUploadFile(null);
     setContentHash(null);
     setHashProgress(0);

--- a/frontend/features/verification/components/steps/__tests__/UploadMedia.test.tsx
+++ b/frontend/features/verification/components/steps/__tests__/UploadMedia.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UploadMedia from '../UploadMedia';
+import { useWizardStore } from '../../../store/wizard.store';
+
+// ── Mocks ──────────────────────────────────────────────
+jest.mock('@/utils/hashing', () => ({
+  hashFile: jest.fn().mockResolvedValue('deadbeef'.repeat(8)),
+}));
+
+let dropzoneOnDrop: (files: File[]) => void = () => {};
+jest.mock('react-dropzone', () => ({
+  useDropzone: ({ onDrop }: { onDrop: (files: File[]) => void }) => {
+    dropzoneOnDrop = onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+    };
+  },
+}));
+
+const mockObjectURL = 'blob:mock-preview-url';
+global.URL.createObjectURL = jest.fn(() => mockObjectURL);
+global.URL.revokeObjectURL = jest.fn();
+
+function createImageFile(name = 'photo.png'): File {
+  return new File(['fake-image-bytes'], name, { type: 'image/png' });
+}
+
+describe('UploadMedia + wizard store', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    act(() => {
+      useWizardStore.getState().resetWizard();
+    });
+  });
+
+  it('saves uploaded file metadata into the global wizard store', async () => {
+    render(<UploadMedia />);
+
+    await act(async () => {
+      dropzoneOnDrop([createImageFile('certificate.png')]);
+      // Let the async hashing promise resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const content = useWizardStore.getState().formData.content;
+    expect(content?.file).toEqual(
+      expect.objectContaining({ name: 'certificate.png', previewUrl: mockObjectURL }),
+    );
+    expect(content?.contentHash).toBe('deadbeef'.repeat(8));
+    expect(useWizardStore.getState().validation[0]).toBe(true);
+  });
+
+  it('restores the file preview from the store after the component remounts', async () => {
+    const { unmount } = render(<UploadMedia />);
+
+    await act(async () => {
+      dropzoneOnDrop([createImageFile('certificate.png')]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Simulate navigating away from and back to this wizard step.
+    unmount();
+    render(<UploadMedia />);
+
+    const preview = await screen.findByAltText('certificate.png');
+    expect(preview).toHaveAttribute('src', mockObjectURL);
+  });
+});


### PR DESCRIPTION
## Summary

closes #424

The wizard's Media Upload step (`UploadMedia.tsx`) already dispatched
uploaded file metadata into the Zustand `wizard.store.ts` on a
successful upload (`setUploadFile`, `setContentHash`, etc.), but the
component rendered the preview thumbnail from **component-local**
state instead of from the store. Since the step components remount on
every wizard navigation, the local `previewUrl` state reset to `null`
even though the file's metadata (including the preview URL) was still
present in `formData.content.file`, so the preview silently reverted
to a generic file icon whenever a user navigated away from and back to
the Media Upload step.

## Changes

- `UploadMedia.tsx` now derives `previewUrl` directly from
  `formData.content.file.previewUrl` in the store instead of
  duplicating it in local state, so the store is the single source of
  truth for the uploaded file's data across the wizard's lifetime.
- Fixed a related stale-closure bug where the object URL revoked on a
  new upload was read from local state rather than the value actually
  tracked in the store.
- Added `UploadMedia.test.tsx` covering:
  - Uploading a file dispatches the correct metadata and hash into the
    wizard store.
  - The file preview is correctly restored from the store after the
    component remounts (simulating step navigation).

## Testing

- `pnpm --filter web exec jest features/verification/components/steps/__tests__/UploadMedia.test.tsx`
- `pnpm --filter web exec eslint features/verification/components/steps/UploadMedia.tsx features/verification/components/steps/__tests__/UploadMedia.test.tsx`
