### PR TITLE
Implement Gas Fee Estimator UI component

### DIFF
--- a/frontend/app/wallet/page.tsx
+++ b/frontend/app/wallet/page.tsx
@@ -26,6 +26,22 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import NetworkBadge from "@/components/wallet/NetworkBadge";
+import GasFeeEstimator, { type GasFeeEstimate } from "@/components/web3/GasFeeEstimator";
+
+/**
+ * Placeholder fee source until live Horizon fee data is wired in.
+ * Base fee is Stellar's network minimum (100 stroops); the small
+ * variance mimics real network congestion for demo purposes.
+ */
+async function fetchMockGasFee(): Promise<GasFeeEstimate> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const baseFeeStroops = 100 + Math.floor(Math.random() * 50);
+  return {
+    baseFeeStroops,
+    estimatedFeeStroops: baseFeeStroops,
+    xlmUsdRate: 0.1 + Math.random() * 0.02,
+  };
+}
 
 export default function WalletDashboardPage() {
   const router = useRouter();
@@ -37,6 +53,45 @@ export default function WalletDashboardPage() {
   const [isLoadingDetails, setIsLoadingDetails] = useState(true);
   const [isFunding, setIsFunding] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  const [gasFee, setGasFee] = useState<GasFeeEstimate | null>(null);
+  const [isLoadingGasFee, setIsLoadingGasFee] = useState(true);
+  const [gasFeeError, setGasFeeError] = useState<string | null>(null);
+  const [gasFeeUpdatedAt, setGasFeeUpdatedAt] = useState<Date | null>(null);
+
+  const loadGasFee = useCallback(async () => {
+    setIsLoadingGasFee(true);
+    setGasFeeError(null);
+    try {
+      const fee = await fetchMockGasFee();
+      setGasFee(fee);
+      setGasFeeUpdatedAt(new Date());
+    } catch {
+      setGasFeeError("Failed to fetch network fee estimate.");
+    } finally {
+      setIsLoadingGasFee(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMockGasFee()
+      .then((fee) => {
+        if (!cancelled) {
+          setGasFee(fee);
+          setGasFeeUpdatedAt(new Date());
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setGasFeeError("Failed to fetch network fee estimate.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingGasFee(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const activeNetwork = networkDetails?.network ?? "testnet";
 
@@ -280,6 +335,17 @@ export default function WalletDashboardPage() {
                   {isLoadingDetails ? "Syncing..." : "Just now"}
                 </span>
               </div>
+            </div>
+
+            {/* Network Fee Estimate */}
+            <div className="pt-5">
+              <GasFeeEstimator
+                data={gasFee}
+                loading={isLoadingGasFee}
+                error={gasFeeError}
+                lastUpdated={gasFeeUpdatedAt}
+                onRefresh={loadGasFee}
+              />
             </div>
           </div>
 

--- a/frontend/components/web3/GasFeeEstimator.tsx
+++ b/frontend/components/web3/GasFeeEstimator.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React from "react";
+import { AlertCircle, Fuel, RefreshCw } from "lucide-react";
+import { Skeleton } from "../ui/Skeleton";
+import { cn } from "../../utils/cn";
+
+/* ------------------------------------------------------------------ */
+/*                              Types                                  */
+/* ------------------------------------------------------------------ */
+
+export type FeeSpeed = "slow" | "standard" | "fast";
+
+export interface GasFeeEstimate {
+  /** Base fee in stroops (1 XLM = 10,000,000 stroops) */
+  baseFeeStroops: number;
+  /** Estimated fee for the selected speed, in stroops */
+  estimatedFeeStroops: number;
+  /** XLM/USD exchange rate used to derive the USD amount */
+  xlmUsdRate: number | null;
+}
+
+export interface GasFeeEstimatorProps {
+  /** Live (or mock) fee data to render. `null` while unavailable. */
+  data: GasFeeEstimate | null;
+  /** True while a fetch is in flight and no data has resolved yet. */
+  loading?: boolean;
+  /** Error message to display instead of the fee data. */
+  error?: string | null;
+  /** When the data was last refreshed. */
+  lastUpdated?: Date | null;
+  /** Called when the user requests a manual refresh. Hides the button if omitted. */
+  onRefresh?: () => void;
+  /** Selected fee speed, purely for label purposes (default: "standard"). */
+  speed?: FeeSpeed;
+  /** Optional class name for the outer container. */
+  className?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*                           Helpers                                   */
+/* ------------------------------------------------------------------ */
+
+const STROOPS_PER_XLM = 10_000_000;
+
+const SPEED_LABEL: Record<FeeSpeed, string> = {
+  slow: "Economy",
+  standard: "Standard",
+  fast: "Priority",
+};
+
+export function stroopsToXlm(stroops: number): number {
+  return stroops / STROOPS_PER_XLM;
+}
+
+function formatXlm(xlm: number): string {
+  const fixed = xlm.toFixed(7).replace(/0+$/, "").replace(/\.$/, "");
+  return fixed === "" ? "0" : fixed;
+}
+
+function formatUsd(usd: number): string {
+  if (usd === 0) return "$0.00";
+  if (usd < 0.000001) return "< $0.000001";
+  return `$${usd.toFixed(6)}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*                         Main Component                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Presentational network-fee estimator card.
+ *
+ * Renders the estimated Stellar transaction fee in both XLM and its
+ * live USD equivalent. This component holds no fetching logic of its
+ * own — callers supply `data` (e.g. from `useGasFeeEstimate`), which
+ * keeps the estimator reusable across the wallet dashboard, the
+ * verification wizard, or any other flow that submits a transaction.
+ */
+export default function GasFeeEstimator({
+  data,
+  loading = false,
+  error = null,
+  lastUpdated = null,
+  onRefresh,
+  speed = "standard",
+  className,
+}: GasFeeEstimatorProps) {
+  const feeXlm = data ? stroopsToXlm(data.estimatedFeeStroops) : null;
+  const feeUsd = data && feeXlm != null && data.xlmUsdRate != null ? feeXlm * data.xlmUsdRate : null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-gray-200 dark:border-gray-700",
+        "bg-white dark:bg-gray-900/60 p-4 space-y-3",
+        className
+      )}
+      role="region"
+      aria-label="Gas fee estimator"
+      data-testid="gas-fee-estimator"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Fuel className="w-4 h-4 text-primary" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+            Network Fee &middot; {SPEED_LABEL[speed]}
+          </h3>
+        </div>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={loading}
+            aria-label="Refresh fee estimate"
+            data-testid="gas-fee-refresh"
+            className="p-1.5 rounded-lg text-gray-400 dark:text-gray-500
+              hover:text-primary dark:hover:text-primary
+              hover:bg-gray-100 dark:hover:bg-gray-800
+              disabled:opacity-40 disabled:cursor-not-allowed
+              transition-colors"
+          >
+            <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} />
+          </button>
+        )}
+      </div>
+
+      {/* Body */}
+      {error ? (
+        <div
+          className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800"
+          data-testid="gas-fee-error"
+        >
+          <AlertCircle className="w-4 h-4 mt-0.5 text-red-500 dark:text-red-400 shrink-0" aria-hidden="true" />
+          <p className="text-xs text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      ) : loading && !data ? (
+        <div className="space-y-2" aria-busy="true" aria-label="Loading fee estimate">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+      ) : data && feeXlm != null ? (
+        <div className="space-y-1" data-testid="gas-fee-values">
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-50 tabular-nums">
+            {formatXlm(feeXlm)}{" "}
+            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">XLM</span>
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+            {feeUsd != null ? `${formatUsd(feeUsd)} USD` : "USD rate unavailable"}
+          </p>
+          <p className="text-[10px] text-gray-400 dark:text-gray-600">
+            Base fee &middot; {data.baseFeeStroops.toLocaleString()} stroops
+          </p>
+        </div>
+      ) : (
+        <p className="text-xs text-gray-500 dark:text-gray-400">No fee estimate available.</p>
+      )}
+
+      {/* Footer timestamp */}
+      {lastUpdated && !error && (
+        <p className="text-[10px] text-gray-400 dark:text-gray-600 pt-1 border-t border-gray-100 dark:border-gray-800">
+          Updated {lastUpdated.toLocaleTimeString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/web3/__tests__/GasFeeEstimator.test.tsx
+++ b/frontend/components/web3/__tests__/GasFeeEstimator.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import GasFeeEstimator, { stroopsToXlm } from "../GasFeeEstimator";
+
+describe("GasFeeEstimator", () => {
+  it("shows a loading skeleton while no data has resolved yet", () => {
+    render(<GasFeeEstimator data={null} loading />);
+    expect(screen.getByLabelText("Loading fee estimate")).toBeInTheDocument();
+  });
+
+  it("shows the error message instead of fee values", () => {
+    render(<GasFeeEstimator data={null} error="Failed to fetch network fee estimate." />);
+    expect(screen.getByTestId("gas-fee-error")).toHaveTextContent(
+      "Failed to fetch network fee estimate.",
+    );
+  });
+
+  it("renders the fee in both XLM and USD", () => {
+    render(
+      <GasFeeEstimator
+        data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: 0.1 }}
+        lastUpdated={new Date()}
+      />,
+    );
+
+    const values = screen.getByTestId("gas-fee-values");
+    expect(values).toHaveTextContent("0.00001");
+    expect(values).toHaveTextContent("XLM");
+    expect(values).toHaveTextContent("USD");
+    expect(values).toHaveTextContent("100 stroops");
+  });
+
+  it("falls back gracefully when the USD rate is unavailable", () => {
+    render(
+      <GasFeeEstimator data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: null }} />,
+    );
+    expect(screen.getByTestId("gas-fee-values")).toHaveTextContent("USD rate unavailable");
+  });
+
+  it("invokes onRefresh when the refresh button is clicked", () => {
+    const onRefresh = jest.fn();
+    render(
+      <GasFeeEstimator
+        data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: 0.1 }}
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("gas-fee-refresh"));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("stroopsToXlm", () => {
+  it("converts stroops to XLM using the 10,000,000 stroop ratio", () => {
+    expect(stroopsToXlm(10_000_000)).toBe(1);
+    expect(stroopsToXlm(100)).toBe(0.00001);
+  });
+});


### PR DESCRIPTION
## Summary

closes #418

Implements the Gas Fee Estimator UI component described in the issue:
a card that shows the estimated Stellar network fee in both XLM and
its USD equivalent, with loading, error, and refresh states.

## Changes

- New `GasFeeEstimator` component at
  `frontend/components/web3/GasFeeEstimator.tsx`. It is intentionally
  presentational/data-source agnostic: it takes a `GasFeeEstimate`
  (`baseFeeStroops`, `estimatedFeeStroops`, `xlmUsdRate`) via props
  instead of fetching internally, so the same component can be reused
  anywhere a fee needs to be shown (wallet dashboard now, the
  verification wizard later, etc.) and fed by whatever data source is
  appropriate for that call site. This keeps it decoupled from the
  live Stellar SDK integration tracked separately in #419.
- Mounted the component on the wallet dashboard
  (`frontend/app/wallet/page.tsx`), backed for now by a small mock fee
  source (`fetchMockGasFee`) so the UI is visible and functional today;
  swapping that source for a live Horizon fee lookup is the scope of
  #419.
- Added `GasFeeEstimator.test.tsx` covering the loading, error, normal,
  missing-USD-rate, and refresh-button states, plus the
  `stroopsToXlm` helper.

## Testing

- `pnpm --filter web exec jest components/web3/__tests__/GasFeeEstimator.test.tsx`
- `pnpm --filter web exec eslint components/web3/GasFeeEstimator.tsx components/web3/__tests__/GasFeeEstimator.test.tsx app/wallet/page.tsx`
- `pnpm --filter web exec next build`
