### PR TITLE
Integrate Gas Fee Estimator with the Stellar Horizon API

### DIFF
--- a/frontend/app/wallet/page.tsx
+++ b/frontend/app/wallet/page.tsx
@@ -26,22 +26,8 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import NetworkBadge from "@/components/wallet/NetworkBadge";
-import GasFeeEstimator, { type GasFeeEstimate } from "@/components/web3/GasFeeEstimator";
-
-/**
- * Placeholder fee source until live Horizon fee data is wired in.
- * Base fee is Stellar's network minimum (100 stroops); the small
- * variance mimics real network congestion for demo purposes.
- */
-async function fetchMockGasFee(): Promise<GasFeeEstimate> {
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  const baseFeeStroops = 100 + Math.floor(Math.random() * 50);
-  return {
-    baseFeeStroops,
-    estimatedFeeStroops: baseFeeStroops,
-    xlmUsdRate: 0.1 + Math.random() * 0.02,
-  };
-}
+import GasFeeEstimator from "@/components/web3/GasFeeEstimator";
+import { useGasFeeEstimate } from "@/hooks/useGasFeeEstimate";
 
 export default function WalletDashboardPage() {
   const router = useRouter();
@@ -54,46 +40,15 @@ export default function WalletDashboardPage() {
   const [isFunding, setIsFunding] = useState(false);
   const [copied, setCopied] = useState(false);
 
-  const [gasFee, setGasFee] = useState<GasFeeEstimate | null>(null);
-  const [isLoadingGasFee, setIsLoadingGasFee] = useState(true);
-  const [gasFeeError, setGasFeeError] = useState<string | null>(null);
-  const [gasFeeUpdatedAt, setGasFeeUpdatedAt] = useState<Date | null>(null);
-
-  const loadGasFee = useCallback(async () => {
-    setIsLoadingGasFee(true);
-    setGasFeeError(null);
-    try {
-      const fee = await fetchMockGasFee();
-      setGasFee(fee);
-      setGasFeeUpdatedAt(new Date());
-    } catch {
-      setGasFeeError("Failed to fetch network fee estimate.");
-    } finally {
-      setIsLoadingGasFee(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetchMockGasFee()
-      .then((fee) => {
-        if (!cancelled) {
-          setGasFee(fee);
-          setGasFeeUpdatedAt(new Date());
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setGasFeeError("Failed to fetch network fee estimate.");
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoadingGasFee(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   const activeNetwork = networkDetails?.network ?? "testnet";
+
+  const {
+    data: gasFee,
+    loading: isLoadingGasFee,
+    error: gasFeeError,
+    lastUpdated: gasFeeUpdatedAt,
+    refresh: loadGasFee,
+  } = useGasFeeEstimate({ network: activeNetwork });
 
   // Redirect disconnected users to /connect
   useEffect(() => {

--- a/frontend/app/wallet/page.tsx
+++ b/frontend/app/wallet/page.tsx
@@ -26,6 +26,22 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import NetworkBadge from "@/components/wallet/NetworkBadge";
+import GasFeeEstimator, { type GasFeeEstimate } from "@/components/web3/GasFeeEstimator";
+
+/**
+ * Placeholder fee source until live Horizon fee data is wired in.
+ * Base fee is Stellar's network minimum (100 stroops); the small
+ * variance mimics real network congestion for demo purposes.
+ */
+async function fetchMockGasFee(): Promise<GasFeeEstimate> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  const baseFeeStroops = 100 + Math.floor(Math.random() * 50);
+  return {
+    baseFeeStroops,
+    estimatedFeeStroops: baseFeeStroops,
+    xlmUsdRate: 0.1 + Math.random() * 0.02,
+  };
+}
 
 export default function WalletDashboardPage() {
   const router = useRouter();
@@ -37,6 +53,45 @@ export default function WalletDashboardPage() {
   const [isLoadingDetails, setIsLoadingDetails] = useState(true);
   const [isFunding, setIsFunding] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  const [gasFee, setGasFee] = useState<GasFeeEstimate | null>(null);
+  const [isLoadingGasFee, setIsLoadingGasFee] = useState(true);
+  const [gasFeeError, setGasFeeError] = useState<string | null>(null);
+  const [gasFeeUpdatedAt, setGasFeeUpdatedAt] = useState<Date | null>(null);
+
+  const loadGasFee = useCallback(async () => {
+    setIsLoadingGasFee(true);
+    setGasFeeError(null);
+    try {
+      const fee = await fetchMockGasFee();
+      setGasFee(fee);
+      setGasFeeUpdatedAt(new Date());
+    } catch {
+      setGasFeeError("Failed to fetch network fee estimate.");
+    } finally {
+      setIsLoadingGasFee(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMockGasFee()
+      .then((fee) => {
+        if (!cancelled) {
+          setGasFee(fee);
+          setGasFeeUpdatedAt(new Date());
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setGasFeeError("Failed to fetch network fee estimate.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingGasFee(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const activeNetwork = networkDetails?.network ?? "testnet";
 
@@ -280,6 +335,17 @@ export default function WalletDashboardPage() {
                   {isLoadingDetails ? "Syncing..." : "Just now"}
                 </span>
               </div>
+            </div>
+
+            {/* Network Fee Estimate */}
+            <div className="pt-5">
+              <GasFeeEstimator
+                data={gasFee}
+                loading={isLoadingGasFee}
+                error={gasFeeError}
+                lastUpdated={gasFeeUpdatedAt}
+                onRefresh={loadGasFee}
+              />
             </div>
           </div>
 

--- a/frontend/components/web3/GasFeeEstimator.tsx
+++ b/frontend/components/web3/GasFeeEstimator.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import React from "react";
+import { AlertCircle, Fuel, RefreshCw } from "lucide-react";
+import { Skeleton } from "../ui/Skeleton";
+import { cn } from "../../utils/cn";
+
+/* ------------------------------------------------------------------ */
+/*                              Types                                  */
+/* ------------------------------------------------------------------ */
+
+export type FeeSpeed = "slow" | "standard" | "fast";
+
+export interface GasFeeEstimate {
+  /** Base fee in stroops (1 XLM = 10,000,000 stroops) */
+  baseFeeStroops: number;
+  /** Estimated fee for the selected speed, in stroops */
+  estimatedFeeStroops: number;
+  /** XLM/USD exchange rate used to derive the USD amount */
+  xlmUsdRate: number | null;
+}
+
+export interface GasFeeEstimatorProps {
+  /** Live (or mock) fee data to render. `null` while unavailable. */
+  data: GasFeeEstimate | null;
+  /** True while a fetch is in flight and no data has resolved yet. */
+  loading?: boolean;
+  /** Error message to display instead of the fee data. */
+  error?: string | null;
+  /** When the data was last refreshed. */
+  lastUpdated?: Date | null;
+  /** Called when the user requests a manual refresh. Hides the button if omitted. */
+  onRefresh?: () => void;
+  /** Selected fee speed, purely for label purposes (default: "standard"). */
+  speed?: FeeSpeed;
+  /** Optional class name for the outer container. */
+  className?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*                           Helpers                                   */
+/* ------------------------------------------------------------------ */
+
+const STROOPS_PER_XLM = 10_000_000;
+
+const SPEED_LABEL: Record<FeeSpeed, string> = {
+  slow: "Economy",
+  standard: "Standard",
+  fast: "Priority",
+};
+
+export function stroopsToXlm(stroops: number): number {
+  return stroops / STROOPS_PER_XLM;
+}
+
+function formatXlm(xlm: number): string {
+  const fixed = xlm.toFixed(7).replace(/0+$/, "").replace(/\.$/, "");
+  return fixed === "" ? "0" : fixed;
+}
+
+function formatUsd(usd: number): string {
+  if (usd === 0) return "$0.00";
+  if (usd < 0.000001) return "< $0.000001";
+  return `$${usd.toFixed(6)}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*                         Main Component                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Presentational network-fee estimator card.
+ *
+ * Renders the estimated Stellar transaction fee in both XLM and its
+ * live USD equivalent. This component holds no fetching logic of its
+ * own — callers supply `data` (e.g. from `useGasFeeEstimate`), which
+ * keeps the estimator reusable across the wallet dashboard, the
+ * verification wizard, or any other flow that submits a transaction.
+ */
+export default function GasFeeEstimator({
+  data,
+  loading = false,
+  error = null,
+  lastUpdated = null,
+  onRefresh,
+  speed = "standard",
+  className,
+}: GasFeeEstimatorProps) {
+  const feeXlm = data ? stroopsToXlm(data.estimatedFeeStroops) : null;
+  const feeUsd = data && feeXlm != null && data.xlmUsdRate != null ? feeXlm * data.xlmUsdRate : null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-gray-200 dark:border-gray-700",
+        "bg-white dark:bg-gray-900/60 p-4 space-y-3",
+        className
+      )}
+      role="region"
+      aria-label="Gas fee estimator"
+      data-testid="gas-fee-estimator"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Fuel className="w-4 h-4 text-primary" aria-hidden="true" />
+          <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+            Network Fee &middot; {SPEED_LABEL[speed]}
+          </h3>
+        </div>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={loading}
+            aria-label="Refresh fee estimate"
+            data-testid="gas-fee-refresh"
+            className="p-1.5 rounded-lg text-gray-400 dark:text-gray-500
+              hover:text-primary dark:hover:text-primary
+              hover:bg-gray-100 dark:hover:bg-gray-800
+              disabled:opacity-40 disabled:cursor-not-allowed
+              transition-colors"
+          >
+            <RefreshCw className={cn("w-3.5 h-3.5", loading && "animate-spin")} />
+          </button>
+        )}
+      </div>
+
+      {/* Body */}
+      {error ? (
+        <div
+          className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800"
+          data-testid="gas-fee-error"
+        >
+          <AlertCircle className="w-4 h-4 mt-0.5 text-red-500 dark:text-red-400 shrink-0" aria-hidden="true" />
+          <p className="text-xs text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      ) : loading && !data ? (
+        <div className="space-y-2" aria-busy="true" aria-label="Loading fee estimate">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+      ) : data && feeXlm != null ? (
+        <div className="space-y-1" data-testid="gas-fee-values">
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-50 tabular-nums">
+            {formatXlm(feeXlm)}{" "}
+            <span className="text-sm font-medium text-gray-500 dark:text-gray-400">XLM</span>
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+            {feeUsd != null ? `${formatUsd(feeUsd)} USD` : "USD rate unavailable"}
+          </p>
+          <p className="text-[10px] text-gray-400 dark:text-gray-600">
+            Base fee &middot; {data.baseFeeStroops.toLocaleString()} stroops
+          </p>
+        </div>
+      ) : (
+        <p className="text-xs text-gray-500 dark:text-gray-400">No fee estimate available.</p>
+      )}
+
+      {/* Footer timestamp */}
+      {lastUpdated && !error && (
+        <p className="text-[10px] text-gray-400 dark:text-gray-600 pt-1 border-t border-gray-100 dark:border-gray-800">
+          Updated {lastUpdated.toLocaleTimeString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/web3/__tests__/GasFeeEstimator.test.tsx
+++ b/frontend/components/web3/__tests__/GasFeeEstimator.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import GasFeeEstimator, { stroopsToXlm } from "../GasFeeEstimator";
+
+describe("GasFeeEstimator", () => {
+  it("shows a loading skeleton while no data has resolved yet", () => {
+    render(<GasFeeEstimator data={null} loading />);
+    expect(screen.getByLabelText("Loading fee estimate")).toBeInTheDocument();
+  });
+
+  it("shows the error message instead of fee values", () => {
+    render(<GasFeeEstimator data={null} error="Failed to fetch network fee estimate." />);
+    expect(screen.getByTestId("gas-fee-error")).toHaveTextContent(
+      "Failed to fetch network fee estimate.",
+    );
+  });
+
+  it("renders the fee in both XLM and USD", () => {
+    render(
+      <GasFeeEstimator
+        data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: 0.1 }}
+        lastUpdated={new Date()}
+      />,
+    );
+
+    const values = screen.getByTestId("gas-fee-values");
+    expect(values).toHaveTextContent("0.00001");
+    expect(values).toHaveTextContent("XLM");
+    expect(values).toHaveTextContent("USD");
+    expect(values).toHaveTextContent("100 stroops");
+  });
+
+  it("falls back gracefully when the USD rate is unavailable", () => {
+    render(
+      <GasFeeEstimator data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: null }} />,
+    );
+    expect(screen.getByTestId("gas-fee-values")).toHaveTextContent("USD rate unavailable");
+  });
+
+  it("invokes onRefresh when the refresh button is clicked", () => {
+    const onRefresh = jest.fn();
+    render(
+      <GasFeeEstimator
+        data={{ baseFeeStroops: 100, estimatedFeeStroops: 100, xlmUsdRate: 0.1 }}
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("gas-fee-refresh"));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("stroopsToXlm", () => {
+  it("converts stroops to XLM using the 10,000,000 stroop ratio", () => {
+    expect(stroopsToXlm(10_000_000)).toBe(1);
+    expect(stroopsToXlm(100)).toBe(0.00001);
+  });
+});

--- a/frontend/hooks/__tests__/useGasFeeEstimate.test.ts
+++ b/frontend/hooks/__tests__/useGasFeeEstimate.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useGasFeeEstimate } from "../useGasFeeEstimate";
+import * as horizonService from "@/services/horizonService";
+
+jest.mock("@/services/horizonService", () => ({
+  fetchBaseFee: jest.fn(),
+  fetchXlmUsdRate: jest.fn(),
+}));
+
+const mockedFetchBaseFee = horizonService.fetchBaseFee as jest.Mock;
+const mockedFetchXlmUsdRate = horizonService.fetchXlmUsdRate as jest.Mock;
+
+describe("useGasFeeEstimate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("combines the live base fee and USD rate into a GasFeeEstimate", async () => {
+    mockedFetchBaseFee.mockResolvedValue({ baseFeeStroops: 100, modeFeeStroops: 300 });
+    mockedFetchXlmUsdRate.mockResolvedValue(0.12);
+
+    const { result } = renderHook(() => useGasFeeEstimate({ network: "testnet", refreshInterval: 0 }));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual({
+      baseFeeStroops: 100,
+      estimatedFeeStroops: 300,
+      xlmUsdRate: 0.12,
+    });
+    expect(result.current.error).toBeNull();
+    expect(mockedFetchBaseFee).toHaveBeenCalledWith("testnet");
+  });
+
+  it("surfaces an error and clears loading if the fetch fails", async () => {
+    mockedFetchBaseFee.mockRejectedValue(new Error("Horizon unreachable"));
+    mockedFetchXlmUsdRate.mockResolvedValue(0.12);
+
+    const { result } = renderHook(() => useGasFeeEstimate({ network: "testnet", refreshInterval: 0 }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Failed to fetch network fee estimate.");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("refetches when refresh() is called", async () => {
+    mockedFetchBaseFee.mockResolvedValue({ baseFeeStroops: 100, modeFeeStroops: 100 });
+    mockedFetchXlmUsdRate.mockResolvedValue(0.1);
+
+    const { result } = renderHook(() => useGasFeeEstimate({ network: "testnet", refreshInterval: 0 }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockedFetchBaseFee).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(mockedFetchBaseFee).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/hooks/useGasFeeEstimate.ts
+++ b/frontend/hooks/useGasFeeEstimate.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { StellarNetworkId } from "@/services/wallet";
+import { fetchBaseFee, fetchXlmUsdRate } from "@/services/horizonService";
+import type { GasFeeEstimate } from "@/components/web3/GasFeeEstimator";
+
+export interface UseGasFeeEstimateOptions {
+  /** Stellar network to query fee stats for. Defaults to "testnet". */
+  network?: StellarNetworkId;
+  /** Auto-refresh interval in ms. Pass 0 to disable. Default: 30_000. */
+  refreshInterval?: number;
+}
+
+export interface UseGasFeeEstimateResult {
+  data: GasFeeEstimate | null;
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetches the current Stellar network fee (via Horizon's `/fee_stats`) and
+ * the live XLM/USD exchange rate, combining them into the shape expected
+ * by `GasFeeEstimator`.
+ *
+ * The estimated fee uses the network's recent "mode" (typical) fee rather
+ * than the bare protocol minimum, so the estimate reflects real network
+ * conditions instead of always showing the 100-stroop floor.
+ */
+export function useGasFeeEstimate({
+  network = "testnet",
+  refreshInterval = 30_000,
+}: UseGasFeeEstimateOptions = {}): UseGasFeeEstimateResult {
+  const [data, setData] = useState<GasFeeEstimate | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    setRefreshToken((token) => token + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([fetchBaseFee(network), fetchXlmUsdRate()])
+      .then(([feeStats, xlmUsdRate]) => {
+        if (cancelled) return;
+        setData({
+          baseFeeStroops: feeStats.baseFeeStroops,
+          estimatedFeeStroops: feeStats.modeFeeStroops,
+          xlmUsdRate,
+        });
+        setError(null);
+        setLastUpdated(new Date());
+      })
+      .catch((err: unknown) => {
+        console.error("useGasFeeEstimate error:", err);
+        if (!cancelled) setError("Failed to fetch network fee estimate.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [network, refreshToken]);
+
+  useEffect(() => {
+    if (!refreshInterval) return;
+    const id = setInterval(refresh, refreshInterval);
+    return () => clearInterval(id);
+  }, [refresh, refreshInterval]);
+
+  return { data, loading, error, lastUpdated, refresh };
+}

--- a/frontend/services/__tests__/horizonService.test.ts
+++ b/frontend/services/__tests__/horizonService.test.ts
@@ -2,6 +2,8 @@ import {
   fetchXlmBalance,
   fetchRecentTransactions,
   fundTestnetAccount,
+  fetchBaseFee,
+  fetchXlmUsdRate,
 } from "../horizonService";
 
 const TEST_KEY = "GBXXYYYYZZZZ";
@@ -103,6 +105,78 @@ describe("horizonService", () => {
 
       const txs = await fetchRecentTransactions(TEST_KEY, "testnet");
       expect(txs).toEqual([]);
+    });
+  });
+
+  describe("fetchBaseFee", () => {
+    it("fetches and parses fee stats from Horizon", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          last_ledger_base_fee: "100",
+          fee_charged: { mode: "250" },
+        }),
+      }) as jest.Mock;
+
+      const stats = await fetchBaseFee("testnet");
+      expect(stats).toEqual({ baseFeeStroops: 100, modeFeeStroops: 250 });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://horizon-testnet.stellar.org/fee_stats",
+        expect.any(Object)
+      );
+    });
+
+    it("uses the mainnet Horizon host when requested", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ last_ledger_base_fee: "100", fee_charged: { mode: "100" } }),
+      }) as jest.Mock;
+
+      await fetchBaseFee("mainnet");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://horizon.stellar.org/fee_stats",
+        expect.any(Object)
+      );
+    });
+
+    it("falls back to the network minimum if the request fails", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network failure"));
+
+      const stats = await fetchBaseFee("testnet");
+      expect(stats).toEqual({ baseFeeStroops: 100, modeFeeStroops: 100 });
+    });
+
+    it("falls back to the network minimum on an unparseable response", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      }) as jest.Mock;
+
+      const stats = await fetchBaseFee("testnet");
+      expect(stats).toEqual({ baseFeeStroops: 100, modeFeeStroops: 100 });
+    });
+  });
+
+  describe("fetchXlmUsdRate", () => {
+    it("fetches the XLM/USD rate from CoinGecko", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ stellar: { usd: 0.115 } }),
+      }) as jest.Mock;
+
+      const rate = await fetchXlmUsdRate();
+      expect(rate).toBe(0.115);
+    });
+
+    it("returns null if the request fails", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network failure"));
+
+      const rate = await fetchXlmUsdRate();
+      expect(rate).toBeNull();
     });
   });
 

--- a/frontend/services/horizonService.ts
+++ b/frontend/services/horizonService.ts
@@ -157,6 +157,89 @@ export async function fetchRecentTransactions(
   }
 }
 
+export interface HorizonFeeStats {
+  /** The base fee (in stroops) charged for the last closed ledger. */
+  baseFeeStroops: number;
+  /** The typical ("mode") fee (in stroops) recently paid on the network. */
+  modeFeeStroops: number;
+}
+
+/** Stellar's protocol-defined minimum base fee, in stroops. Used as a fallback. */
+const MIN_BASE_FEE_STROOPS = 100;
+
+/**
+ * Fetches the current network base fee from Horizon's `/fee_stats` endpoint.
+ * Falls back to the network minimum base fee if the request fails, so
+ * callers can always render a usable (if conservative) estimate.
+ */
+export async function fetchBaseFee(network: StellarNetworkId): Promise<HorizonFeeStats> {
+  const isMock =
+    typeof process !== "undefined" && process.env.NEXT_PUBLIC_MOCK_WALLET === "true";
+
+  if (isMock) {
+    return { baseFeeStroops: MIN_BASE_FEE_STROOPS, modeFeeStroops: MIN_BASE_FEE_STROOPS };
+  }
+
+  const baseUrl =
+    network === "mainnet"
+      ? "https://horizon.stellar.org"
+      : "https://horizon-testnet.stellar.org";
+
+  try {
+    const res = await fetch(`${baseUrl}/fee_stats`, { cache: "no-store" });
+
+    if (!res.ok) {
+      throw new Error(`Horizon fee_stats fetch failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    const baseFeeStroops = parseInt(data.last_ledger_base_fee, 10);
+    const modeFeeStroops = parseInt(data.fee_charged?.mode, 10);
+
+    return {
+      baseFeeStroops: Number.isFinite(baseFeeStroops) ? baseFeeStroops : MIN_BASE_FEE_STROOPS,
+      modeFeeStroops: Number.isFinite(modeFeeStroops) ? modeFeeStroops : MIN_BASE_FEE_STROOPS,
+    };
+  } catch (err) {
+    console.error("fetchBaseFee error, falling back to network minimum:", err);
+    return { baseFeeStroops: MIN_BASE_FEE_STROOPS, modeFeeStroops: MIN_BASE_FEE_STROOPS };
+  }
+}
+
+/**
+ * Fetches the current XLM/USD exchange rate from CoinGecko's public API.
+ * Returns `null` (rather than throwing) if the rate cannot be fetched, so
+ * callers can still display the fee in XLM even when a USD quote is
+ * unavailable.
+ */
+export async function fetchXlmUsdRate(): Promise<number | null> {
+  const isMock =
+    typeof process !== "undefined" && process.env.NEXT_PUBLIC_MOCK_WALLET === "true";
+
+  if (isMock) {
+    return 0.11;
+  }
+
+  try {
+    const res = await fetch(
+      "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd",
+      { cache: "no-store" }
+    );
+
+    if (!res.ok) {
+      throw new Error(`CoinGecko price fetch failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    const rate = data?.stellar?.usd;
+
+    return typeof rate === "number" ? rate : null;
+  } catch (err) {
+    console.error("fetchXlmUsdRate error:", err);
+    return null;
+  }
+}
+
 /**
  * Requests 10,000 testnet XLM from Friendbot for the specified address.
  */


### PR DESCRIPTION
## Summary

closes #419

Connects the `GasFeeEstimator` component to live Stellar network data,
replacing the placeholder mock fee source it shipped with in #418.

Note: this branch is built on top of #502 (Gas Fee Estimator UI, #418)
since both issues touch the same component. Once #502 merges, this
diff will narrow down to just the changes described below.

## Changes

- `services/horizonService.ts`: added `fetchBaseFee(network)`, which
  reads Horizon's `/fee_stats` endpoint for the last ledger's base fee
  and the network's recent typical ("mode") fee, and
  `fetchXlmUsdRate()`, which reads the current XLM/USD price from
  CoinGecko's public price API. Both fall back to a safe default (the
  100-stroop network minimum, or a `null` USD rate) on failure so the
  UI always has something reasonable to render, matching the existing
  fallback conventions already used elsewhere in this file
  (`fetchXlmBalance`, `fetchRecentTransactions`).
- New `hooks/useGasFeeEstimate.ts` combines both calls into the
  `GasFeeEstimate` shape `GasFeeEstimator` expects, and exposes
  `loading`, `error`, `lastUpdated`, and a `refresh()` used both for
  manual refresh and a 30s auto-refresh interval.
- The wallet dashboard (`app/wallet/page.tsx`) now uses
  `useGasFeeEstimate`, scoped to the connected wallet's network,
  instead of the temporary mock fee generator.

## Testing

- `pnpm --filter web exec jest services/__tests__/horizonService.test.ts hooks/__tests__/useGasFeeEstimate.test.ts`
- `pnpm --filter web exec eslint app/wallet/page.tsx hooks/useGasFeeEstimate.ts services/horizonService.ts`
- `pnpm --filter web exec next build`
