### PR TITLE
fix(frontend): prevent duplicate verification submissions

### DIFF
--- a/frontend/features/verification/components/steps/ReviewSubmitStep.tsx
+++ b/frontend/features/verification/components/steps/ReviewSubmitStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import {
   CheckCircle2,
   Edit2,
@@ -248,6 +248,7 @@ export default function ReviewSubmitStep({ onNavigate }: ReviewSubmitStepProps) 
   } = useWizardStore();
 
   const [confirmed, setConfirmed] = useState(false);
+  const submissionLockRef = useRef(false);
   const content = formData.content;
   const isEncrypted = content?.encryptionEnabled ?? true;
   const contentHashValid = isValidSHA256(content?.contentHash ?? '');
@@ -275,8 +276,9 @@ export default function ReviewSubmitStep({ onNavigate }: ReviewSubmitStepProps) 
   };
 
   const handleSubmit = useCallback(async () => {
-    if (!canSubmit) return;
+    if (!canSubmit || submissionLockRef.current) return;
 
+    submissionLockRef.current = true;
     setIsSubmitting(true);
     setSubmissionError(null);
 
@@ -312,6 +314,7 @@ export default function ReviewSubmitStep({ onNavigate }: ReviewSubmitStepProps) 
       const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
       setSubmissionError(errorMessage);
     } finally {
+      submissionLockRef.current = false;
       setIsSubmitting(false);
     }
   }, [canSubmit, content, setIsSubmitting, setSubmissionResult, setSubmissionError]);


### PR DESCRIPTION
Closes #443

## Summary
- Add an immediate component-level submission lock to the verification review step.
- Prevent rapid clicks from starting multiple verification transactions before React state updates.
- Release the lock in `finally` so retries remain available after success or failure.

## Scope
The change is limited to `frontend/features/verification/components/steps/ReviewSubmitStep.tsx`, matching the issue's React State technical scope and acceptance criteria.

## Validation
- Editor diagnostics: no errors in the changed component.
- ESLint: no errors; existing warnings remain for the unused `Upload` import and raw `<img>` usage.
- `git diff --check`: passed.
- Jest and full TypeScript validation are currently blocked by existing repository setup issues: missing `ts-node` for `jest.config.ts` and unrelated stale test imports/type errors.
