### PR TITLE
feat(billing): complete the invoices table view

### DIFF
--- a/frontend/app/dashboard/billing/__tests__/invoices.test.tsx
+++ b/frontend/app/dashboard/billing/__tests__/invoices.test.tsx
@@ -103,4 +103,51 @@ describe("InvoicesView", () => {
     render(<InvoicesView />);
     expect(await screen.findByText("No invoices yet.")).toBeInTheDocument();
   });
+
+  it("renders the invoice summary and both dates", async () => {
+    render(<InvoicesView />);
+    expect(await screen.findByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Issued" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Due" })).toBeInTheDocument();
+  });
+
+  it("shows an error state and reloads when the fetch fails", async () => {
+    (fetchInvoices as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+    render(<InvoicesView />);
+
+    expect(await screen.findByTestId("invoices-error")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(fetchInvoices).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("InvoicesView (controlled)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the invoices passed in without fetching", () => {
+    render(<InvoicesView invoices={SAMPLE_INVOICES} showHeader={false} />);
+
+    expect(screen.getByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(fetchInvoices).not.toHaveBeenCalled();
+    expect(screen.queryByRole("heading", { name: /Billing & Invoices/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the loading state from props", () => {
+    render(<InvoicesView invoices={[]} isLoading />);
+    expect(screen.getByRole("status")).toHaveTextContent(/loading invoices/i);
+  });
+
+  it("renders the error from props and calls onRetry", () => {
+    const onRetry = jest.fn();
+    render(<InvoicesView invoices={[]} error="Billing API unavailable" onRetry={onRetry} />);
+
+    expect(screen.getByText("Billing API unavailable")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/app/dashboard/billing/invoices.tsx
+++ b/frontend/app/dashboard/billing/invoices.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { pdf } from "@react-pdf/renderer";
-import { Download, FileText, Loader2, Receipt } from "lucide-react";
+import { AlertCircle, Download, FileText, Loader2, Receipt } from "lucide-react";
 import { useAuth } from "@/app/context/AuthContext";
 import { useToast } from "@/context/ToastContext";
 import { fetchInvoices, invoiceTotal, type Invoice, type InvoiceStatus } from "@/services/billingMock";
@@ -21,6 +21,13 @@ function formatDate(iso: string): string {
   });
 }
 
+/** One-line summary of what an invoice covers, shown under its id. */
+function invoiceSummary(invoice: Invoice): string {
+  const [first, ...rest] = invoice.lineItems;
+  if (!first) return "No line items";
+  return rest.length > 0 ? `${first.description} +${rest.length} more` : first.description;
+}
+
 const STATUS_STYLE: Record<InvoiceStatus, string> = {
   paid: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border border-green-200 dark:border-green-800",
   pending: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-800",
@@ -37,29 +44,80 @@ export async function downloadInvoicePdf(invoice: Invoice): Promise<void> {
   downloadBlob(blob, `${invoice.id}.pdf`);
 }
 
-export default function InvoicesView() {
+export interface InvoicesViewProps {
+  /**
+   * Invoices to render. When provided, the view is fully controlled and does
+   * not fetch anything itself, so a parent (e.g. the billing dashboard) can
+   * own the data source. When omitted, the view loads the signed-in user's
+   * invoices itself.
+   */
+  invoices?: Invoice[];
+  /** Loading flag, controlled mode only. */
+  isLoading?: boolean;
+  /** Error message, controlled mode only; renders the error state. */
+  error?: string | null;
+  /** Called when the user presses "Try again" in the error state. */
+  onRetry?: () => void;
+  /** Hides the title block when the parent already renders one. */
+  showHeader?: boolean;
+}
+
+export default function InvoicesView({
+  invoices: invoicesProp,
+  isLoading: isLoadingProp,
+  error: errorProp,
+  onRetry,
+  showHeader = true,
+}: InvoicesViewProps = {}) {
   const { user } = useAuth();
   const { addToast } = useToast();
 
   const email = user?.email ?? "user@stellarproof.com";
+  const isControlled = invoicesProp !== undefined;
 
-  const [invoices, setInvoices] = useState<Invoice[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [ownInvoices, setOwnInvoices] = useState<Invoice[]>([]);
+  const [isOwnLoading, setIsOwnLoading] = useState(true);
+  const [ownError, setOwnError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isControlled) return;
+
     let cancelled = false;
+
     fetchInvoices(email)
       .then((data) => {
-        if (!cancelled) setInvoices(data);
+        if (!cancelled) setOwnInvoices(data);
+      })
+      .catch((err) => {
+        console.error("Failed to load invoices:", err);
+        if (!cancelled) setOwnError("We could not load your invoices. Please try again.");
       })
       .finally(() => {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setIsOwnLoading(false);
       });
+
     return () => {
       cancelled = true;
     };
-  }, [email]);
+  }, [email, isControlled, reloadToken]);
+
+  const invoices = isControlled ? invoicesProp : ownInvoices;
+  const isLoading = isControlled ? isLoadingProp === true : isOwnLoading;
+  const error = isControlled ? errorProp ?? null : ownError;
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry();
+      return;
+    }
+    // Re-arm the loading state here rather than in the effect, so the effect
+    // body stays free of synchronous setState calls.
+    setIsOwnLoading(true);
+    setOwnError(null);
+    setReloadToken((token) => token + 1);
+  }, [onRetry]);
 
   const handleDownload = useCallback(
     async (invoice: Invoice) => {
@@ -78,26 +136,48 @@ export default function InvoicesView() {
 
   return (
     <div className="w-full space-y-6">
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 border border-primary/20">
-          <Receipt className="h-5 w-5 text-primary" />
+      {showHeader && (
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 border border-primary/20">
+            <Receipt className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Billing &amp; Invoices</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              View and download PDF copies of your past invoices.
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Billing & Invoices</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            View and download PDF copies of your past invoices.
-          </p>
-        </div>
-      </div>
+      )}
 
       <div
         className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-darkblue shadow-sm overflow-hidden"
         data-testid="invoices-panel"
       >
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
+          <div
+            className="flex items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400"
+            role="status"
+            aria-live="polite"
+          >
             <Loader2 className="h-5 w-5 animate-spin" />
             <span className="text-sm">Loading invoices…</span>
+          </div>
+        ) : error ? (
+          <div
+            className="flex flex-col items-center justify-center gap-3 py-16 text-center"
+            role="alert"
+            data-testid="invoices-error"
+          >
+            <AlertCircle className="h-10 w-10 text-red-400" />
+            <p className="text-sm text-gray-600 dark:text-gray-300">{error}</p>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white hover:bg-primary/90 transition-colors"
+            >
+              Try again
+            </button>
           </div>
         ) : invoices.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
@@ -107,10 +187,19 @@ export default function InvoicesView() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-left text-sm">
+              <caption className="sr-only">
+                Your invoices, with issue date, due date, status, amount and a PDF download.
+              </caption>
               <thead className="bg-gray-50 dark:bg-white/5 border-b border-gray-200 dark:border-white/10">
                 <tr>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Invoice</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Issued</th>
+                  <th
+                    scope="col"
+                    className="hidden px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 md:table-cell"
+                  >
+                    Due
+                  </th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Status</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 text-right">Amount</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 text-right">
@@ -122,11 +211,27 @@ export default function InvoicesView() {
                 {invoices.map((invoice) => {
                   const isDownloading = downloadingId === invoice.id;
                   return (
-                    <tr key={invoice.id} data-testid={`invoice-row-${invoice.id}`}>
-                      <td className="px-6 py-4 font-medium text-gray-900 dark:text-white">{invoice.id}</td>
-                      <td className="px-6 py-4 text-gray-600 dark:text-gray-300">{formatDate(invoice.issuedAt)}</td>
+                    <tr
+                      key={invoice.id}
+                      data-testid={`invoice-row-${invoice.id}`}
+                      className="transition-colors hover:bg-gray-50 dark:hover:bg-white/5"
+                    >
                       <td className="px-6 py-4">
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${STATUS_STYLE[invoice.status]}`}>
+                        <span className="block font-medium text-gray-900 dark:text-white">{invoice.id}</span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400">
+                          {invoiceSummary(invoice)}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-gray-600 dark:text-gray-300">
+                        {formatDate(invoice.issuedAt)}
+                      </td>
+                      <td className="hidden whitespace-nowrap px-6 py-4 text-gray-600 dark:text-gray-300 md:table-cell">
+                        {formatDate(invoice.dueAt)}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${STATUS_STYLE[invoice.status]}`}
+                        >
                           {invoice.status}
                         </span>
                       </td>


### PR DESCRIPTION
Closes #413

## Goal

Finish the billing invoices table view so it renders accurately as a standalone page and can also be driven by the billing dashboard.

`app/dashboard/billing/invoices.tsx` already had the base table and the Download PDF action. This PR rounds out the states and the structure the table was missing.

## What changed

**Controlled mode** — `InvoicesView` now accepts props:

| Prop | Purpose |
| --- | --- |
| `invoices` | Renders exactly these invoices and skips the internal fetch |
| `isLoading` | Loading state, controlled mode only |
| `error` | Error message, controlled mode only |
| `onRetry` | Handler for the "Try again" action |
| `showHeader` | Hides the title block when the parent renders its own |

With no props the component behaves exactly as before and loads the signed-in user's invoices itself, so the existing `/dashboard/billing` route is unaffected.

**Error state** — a failed load now renders an alert with a "Try again" action that re-runs the fetch, instead of falling through to an empty table that looks like "you have no invoices".

**Table detail** — each row shows the line-item summary under the invoice id (`Pro plan +2 more`), and a due-date column was added. The due column collapses below the `md` breakpoint so the remaining columns stay readable on narrow screens rather than forcing a horizontal scroll.

**Accessibility** — `sr-only` caption on the table, `role="status"` with `aria-live` on the loading region, `role="alert"` on the error region. The per-row button keeps its `aria-label` naming the invoice.

The loading state is re-armed in the retry handler rather than in the effect body, which keeps `react-hooks/set-state-in-effect` satisfied.

## Tests

`app/dashboard/billing/__tests__/invoices.test.tsx` gains coverage for the summary and date columns, the error state and its retry path, and the three controlled-mode states (data, loading, error with `onRetry`). The five existing cases are untouched and still pass.

```
Tests: 10 passed, 10 total
```

`pnpm --filter web run lint` and `pnpm --filter web run build` both pass.

## Notes for review

- No visual regression to the existing page: the same table, plus one column and two new states.
- The controlled props are what let the billing dashboard own the data source in #414.
