### PR TITLE
test(billing): unit tests for the billing dashboard and invoice list

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,7 @@
 # Base URL of the StellarProof backend API (Express + MongoDB, fronts the
 # Soroban provenance contract index). Used by the search page to fetch real
-# certificate data via GET /api/v1/certificates.
+# certificate data via GET /api/v1/certificates, and by the billing dashboard
+# via GET /api/v1/users/me/subscription and GET /api/v1/users/me/invoices.
 # Local development default:
 NEXT_PUBLIC_API_URL=http://localhost:4000
 

--- a/frontend/app/dashboard/billing/__tests__/billing.test.tsx
+++ b/frontend/app/dashboard/billing/__tests__/billing.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the billing dashboard page: rendering of the subscription
+ * card and invoice table from mocked API responses, plus the loading, error
+ * and sample-data states.
+ */
+
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import BillingPage from "../page";
+import type { Invoice, Subscription } from "@/services/billingMock";
+
+jest.mock("@react-pdf/renderer", () => ({
+  pdf: jest.fn(() => ({
+    toBlob: jest.fn().mockResolvedValue(new Blob(["%PDF-1.4 fake"], { type: "application/pdf" })),
+  })),
+  Document: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Page: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  View: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+
+jest.mock("@/utils/downloadBlob", () => ({ downloadBlob: jest.fn() }));
+
+jest.mock("@/context/ToastContext", () => ({
+  useToast: () => ({ addToast: jest.fn() }),
+}));
+
+jest.mock("@/app/context/AuthContext", () => ({
+  useAuth: () => ({ user: { email: "buyer@example.com" } }),
+}));
+
+jest.mock("@/services/billingService", () => ({
+  fetchSubscription: jest.fn(),
+  fetchBillingInvoices: jest.fn(),
+}));
+
+import { fetchBillingInvoices, fetchSubscription } from "@/services/billingService";
+
+const mockFetchSubscription = fetchSubscription as jest.Mock;
+const mockFetchInvoices = fetchBillingInvoices as jest.Mock;
+
+const SUBSCRIPTION: Subscription = {
+  planName: "Personal",
+  status: "active",
+  priceUsd: 9,
+  interval: "month",
+  currentPeriodEnd: new Date("2026-09-15T00:00:00.000Z").toISOString(),
+  cancelAtPeriodEnd: false,
+  verificationsUsed: 12,
+  verificationsIncluded: 100,
+};
+
+const INVOICES: Invoice[] = [
+  {
+    id: "INV-2026-0002",
+    issuedAt: new Date("2026-08-01T00:00:00.000Z").toISOString(),
+    dueAt: new Date("2026-08-31T00:00:00.000Z").toISOString(),
+    status: "overdue",
+    billedToName: "Test User",
+    billedToEmail: "buyer@example.com",
+    currency: "USD",
+    lineItems: [{ description: "Personal plan", quantity: 1, unitPrice: 9 }],
+  },
+  {
+    id: "INV-2026-0001",
+    issuedAt: new Date("2026-07-01T00:00:00.000Z").toISOString(),
+    dueAt: new Date("2026-07-31T00:00:00.000Z").toISOString(),
+    status: "paid",
+    billedToName: "Test User",
+    billedToEmail: "buyer@example.com",
+    currency: "USD",
+    lineItems: [
+      { description: "Personal plan", quantity: 1, unitPrice: 9 },
+      { description: "Extra certificate mints", quantity: 2, unitPrice: 1.5 },
+    ],
+  },
+];
+
+function mockApiData(source: "api" | "sample" = "api") {
+  mockFetchSubscription.mockResolvedValue({ data: SUBSCRIPTION, source });
+  mockFetchInvoices.mockResolvedValue({ data: INVOICES, source });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApiData();
+});
+
+describe("BillingPage", () => {
+  it("requests the signed-in user's billing data", async () => {
+    render(<BillingPage />);
+
+    await waitFor(() => expect(screen.getByTestId("subscription-card")).toBeInTheDocument());
+
+    expect(mockFetchSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "buyer@example.com" }),
+    );
+    expect(mockFetchInvoices).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "buyer@example.com" }),
+    );
+  });
+
+  it("shows skeletons while the data is loading", () => {
+    mockFetchSubscription.mockReturnValue(new Promise(() => {}));
+    mockFetchInvoices.mockReturnValue(new Promise(() => {}));
+
+    render(<BillingPage />);
+
+    expect(screen.getByTestId("subscription-skeleton")).toBeInTheDocument();
+    expect(screen.getByText(/loading invoices/i)).toBeInTheDocument();
+  });
+
+  it("populates the subscription card from the API response", async () => {
+    render(<BillingPage />);
+
+    const card = await screen.findByTestId("subscription-card");
+
+    expect(within(card).getByRole("heading", { name: /Personal plan/i })).toBeInTheDocument();
+    expect(within(card).getByText("$9.00 per month")).toBeInTheDocument();
+    expect(within(card).getByTestId("subscription-status")).toHaveTextContent("Active");
+    expect(within(card).getByText("Renews on")).toBeInTheDocument();
+    expect(within(card).getByText("12 of 100")).toBeInTheDocument();
+  });
+
+  it("populates the invoice table from the API response", async () => {
+    render(<BillingPage />);
+
+    const firstRow = await screen.findByTestId("invoice-row-INV-2026-0002");
+    const secondRow = screen.getByTestId("invoice-row-INV-2026-0001");
+
+    expect(within(firstRow).getByText("overdue")).toBeInTheDocument();
+    expect(within(firstRow).getByText("$9.00")).toBeInTheDocument();
+
+    // Totals are summed across every line item.
+    expect(within(secondRow).getByText("$12.00")).toBeInTheDocument();
+    expect(within(secondRow).getByText("Personal plan +1 more")).toBeInTheDocument();
+
+    expect(screen.getAllByRole("button", { name: /Download PDF for invoice/i })).toHaveLength(2);
+  });
+
+  it("sums the outstanding balance across unpaid invoices", async () => {
+    render(<BillingPage />);
+
+    expect(await screen.findByTestId("outstanding-total")).toHaveTextContent(
+      "Outstanding balance: $9.00",
+    );
+  });
+
+  it("hides the outstanding balance when everything is paid", async () => {
+    mockFetchInvoices.mockResolvedValue({
+      data: [{ ...INVOICES[0], status: "paid" as const }, INVOICES[1]],
+      source: "api",
+    });
+
+    render(<BillingPage />);
+
+    await screen.findByTestId("invoice-row-INV-2026-0002");
+    expect(screen.queryByTestId("outstanding-total")).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when the user has no invoices", async () => {
+    mockFetchInvoices.mockResolvedValue({ data: [], source: "api" });
+
+    render(<BillingPage />);
+
+    expect(await screen.findByText("No invoices yet.")).toBeInTheDocument();
+  });
+
+  it("does not warn about sample data when both responses are live", async () => {
+    render(<BillingPage />);
+
+    await screen.findByTestId("subscription-card");
+    expect(screen.queryByTestId("sample-data-notice")).not.toBeInTheDocument();
+  });
+
+  it("warns when any part of the response is sample data", async () => {
+    mockFetchInvoices.mockResolvedValue({ data: INVOICES, source: "sample" });
+
+    render(<BillingPage />);
+
+    expect(await screen.findByTestId("sample-data-notice")).toBeInTheDocument();
+  });
+
+  it("renders the cancellation wording when auto-renewal is off", async () => {
+    mockFetchSubscription.mockResolvedValue({
+      data: { ...SUBSCRIPTION, cancelAtPeriodEnd: true },
+      source: "api",
+    });
+
+    render(<BillingPage />);
+
+    const card = await screen.findByTestId("subscription-card");
+    expect(within(card).getByText("Access until")).toBeInTheDocument();
+    expect(within(card).getByText("Auto-renewal is off")).toBeInTheDocument();
+    expect(within(card).getByText("None")).toBeInTheDocument();
+  });
+
+  it("shows an error state and reloads the data on retry", async () => {
+    const user = userEvent.setup();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockFetchInvoices.mockRejectedValueOnce(new Error("boom"));
+
+    render(<BillingPage />);
+
+    expect(await screen.findByTestId("invoices-error")).toBeInTheDocument();
+
+    mockApiData();
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByTestId("invoice-row-INV-2026-0002")).toBeInTheDocument();
+    expect(mockFetchInvoices).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/app/dashboard/billing/__tests__/invoices.test.tsx
+++ b/frontend/app/dashboard/billing/__tests__/invoices.test.tsx
@@ -103,4 +103,51 @@ describe("InvoicesView", () => {
     render(<InvoicesView />);
     expect(await screen.findByText("No invoices yet.")).toBeInTheDocument();
   });
+
+  it("renders the invoice summary and both dates", async () => {
+    render(<InvoicesView />);
+    expect(await screen.findByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Issued" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Due" })).toBeInTheDocument();
+  });
+
+  it("shows an error state and reloads when the fetch fails", async () => {
+    (fetchInvoices as jest.Mock).mockRejectedValueOnce(new Error("network down"));
+    render(<InvoicesView />);
+
+    expect(await screen.findByTestId("invoices-error")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(fetchInvoices).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("InvoicesView (controlled)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the invoices passed in without fetching", () => {
+    render(<InvoicesView invoices={SAMPLE_INVOICES} showHeader={false} />);
+
+    expect(screen.getByTestId("invoice-row-INV-2026-0001")).toBeInTheDocument();
+    expect(fetchInvoices).not.toHaveBeenCalled();
+    expect(screen.queryByRole("heading", { name: /Billing & Invoices/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the loading state from props", () => {
+    render(<InvoicesView invoices={[]} isLoading />);
+    expect(screen.getByRole("status")).toHaveTextContent(/loading invoices/i);
+  });
+
+  it("renders the error from props and calls onRetry", () => {
+    const onRetry = jest.fn();
+    render(<InvoicesView invoices={[]} error="Billing API unavailable" onRetry={onRetry} />);
+
+    expect(screen.getByText("Billing API unavailable")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/app/dashboard/billing/invoices.tsx
+++ b/frontend/app/dashboard/billing/invoices.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { pdf } from "@react-pdf/renderer";
-import { Download, FileText, Loader2, Receipt } from "lucide-react";
+import { AlertCircle, Download, FileText, Loader2, Receipt } from "lucide-react";
 import { useAuth } from "@/app/context/AuthContext";
 import { useToast } from "@/context/ToastContext";
 import { fetchInvoices, invoiceTotal, type Invoice, type InvoiceStatus } from "@/services/billingMock";
@@ -21,6 +21,13 @@ function formatDate(iso: string): string {
   });
 }
 
+/** One-line summary of what an invoice covers, shown under its id. */
+function invoiceSummary(invoice: Invoice): string {
+  const [first, ...rest] = invoice.lineItems;
+  if (!first) return "No line items";
+  return rest.length > 0 ? `${first.description} +${rest.length} more` : first.description;
+}
+
 const STATUS_STYLE: Record<InvoiceStatus, string> = {
   paid: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border border-green-200 dark:border-green-800",
   pending: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-800",
@@ -37,29 +44,80 @@ export async function downloadInvoicePdf(invoice: Invoice): Promise<void> {
   downloadBlob(blob, `${invoice.id}.pdf`);
 }
 
-export default function InvoicesView() {
+export interface InvoicesViewProps {
+  /**
+   * Invoices to render. When provided, the view is fully controlled and does
+   * not fetch anything itself, so a parent (e.g. the billing dashboard) can
+   * own the data source. When omitted, the view loads the signed-in user's
+   * invoices itself.
+   */
+  invoices?: Invoice[];
+  /** Loading flag, controlled mode only. */
+  isLoading?: boolean;
+  /** Error message, controlled mode only; renders the error state. */
+  error?: string | null;
+  /** Called when the user presses "Try again" in the error state. */
+  onRetry?: () => void;
+  /** Hides the title block when the parent already renders one. */
+  showHeader?: boolean;
+}
+
+export default function InvoicesView({
+  invoices: invoicesProp,
+  isLoading: isLoadingProp,
+  error: errorProp,
+  onRetry,
+  showHeader = true,
+}: InvoicesViewProps = {}) {
   const { user } = useAuth();
   const { addToast } = useToast();
 
   const email = user?.email ?? "user@stellarproof.com";
+  const isControlled = invoicesProp !== undefined;
 
-  const [invoices, setInvoices] = useState<Invoice[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const [ownInvoices, setOwnInvoices] = useState<Invoice[]>([]);
+  const [isOwnLoading, setIsOwnLoading] = useState(true);
+  const [ownError, setOwnError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isControlled) return;
+
     let cancelled = false;
+
     fetchInvoices(email)
       .then((data) => {
-        if (!cancelled) setInvoices(data);
+        if (!cancelled) setOwnInvoices(data);
+      })
+      .catch((err) => {
+        console.error("Failed to load invoices:", err);
+        if (!cancelled) setOwnError("We could not load your invoices. Please try again.");
       })
       .finally(() => {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setIsOwnLoading(false);
       });
+
     return () => {
       cancelled = true;
     };
-  }, [email]);
+  }, [email, isControlled, reloadToken]);
+
+  const invoices = isControlled ? invoicesProp : ownInvoices;
+  const isLoading = isControlled ? isLoadingProp === true : isOwnLoading;
+  const error = isControlled ? errorProp ?? null : ownError;
+
+  const handleRetry = useCallback(() => {
+    if (onRetry) {
+      onRetry();
+      return;
+    }
+    // Re-arm the loading state here rather than in the effect, so the effect
+    // body stays free of synchronous setState calls.
+    setIsOwnLoading(true);
+    setOwnError(null);
+    setReloadToken((token) => token + 1);
+  }, [onRetry]);
 
   const handleDownload = useCallback(
     async (invoice: Invoice) => {
@@ -78,26 +136,48 @@ export default function InvoicesView() {
 
   return (
     <div className="w-full space-y-6">
-      <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 border border-primary/20">
-          <Receipt className="h-5 w-5 text-primary" />
+      {showHeader && (
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 border border-primary/20">
+            <Receipt className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Billing &amp; Invoices</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              View and download PDF copies of your past invoices.
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Billing & Invoices</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            View and download PDF copies of your past invoices.
-          </p>
-        </div>
-      </div>
+      )}
 
       <div
         className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-darkblue shadow-sm overflow-hidden"
         data-testid="invoices-panel"
       >
         {isLoading ? (
-          <div className="flex items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400">
+          <div
+            className="flex items-center justify-center gap-2 py-16 text-gray-500 dark:text-gray-400"
+            role="status"
+            aria-live="polite"
+          >
             <Loader2 className="h-5 w-5 animate-spin" />
             <span className="text-sm">Loading invoices…</span>
+          </div>
+        ) : error ? (
+          <div
+            className="flex flex-col items-center justify-center gap-3 py-16 text-center"
+            role="alert"
+            data-testid="invoices-error"
+          >
+            <AlertCircle className="h-10 w-10 text-red-400" />
+            <p className="text-sm text-gray-600 dark:text-gray-300">{error}</p>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white hover:bg-primary/90 transition-colors"
+            >
+              Try again
+            </button>
           </div>
         ) : invoices.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
@@ -107,10 +187,19 @@ export default function InvoicesView() {
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-left text-sm">
+              <caption className="sr-only">
+                Your invoices, with issue date, due date, status, amount and a PDF download.
+              </caption>
               <thead className="bg-gray-50 dark:bg-white/5 border-b border-gray-200 dark:border-white/10">
                 <tr>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Invoice</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Issued</th>
+                  <th
+                    scope="col"
+                    className="hidden px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 md:table-cell"
+                  >
+                    Due
+                  </th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300">Status</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 text-right">Amount</th>
                   <th scope="col" className="px-6 py-3 font-semibold text-gray-600 dark:text-gray-300 text-right">
@@ -122,11 +211,27 @@ export default function InvoicesView() {
                 {invoices.map((invoice) => {
                   const isDownloading = downloadingId === invoice.id;
                   return (
-                    <tr key={invoice.id} data-testid={`invoice-row-${invoice.id}`}>
-                      <td className="px-6 py-4 font-medium text-gray-900 dark:text-white">{invoice.id}</td>
-                      <td className="px-6 py-4 text-gray-600 dark:text-gray-300">{formatDate(invoice.issuedAt)}</td>
+                    <tr
+                      key={invoice.id}
+                      data-testid={`invoice-row-${invoice.id}`}
+                      className="transition-colors hover:bg-gray-50 dark:hover:bg-white/5"
+                    >
                       <td className="px-6 py-4">
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${STATUS_STYLE[invoice.status]}`}>
+                        <span className="block font-medium text-gray-900 dark:text-white">{invoice.id}</span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400">
+                          {invoiceSummary(invoice)}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-gray-600 dark:text-gray-300">
+                        {formatDate(invoice.issuedAt)}
+                      </td>
+                      <td className="hidden whitespace-nowrap px-6 py-4 text-gray-600 dark:text-gray-300 md:table-cell">
+                        {formatDate(invoice.dueAt)}
+                      </td>
+                      <td className="px-6 py-4">
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${STATUS_STYLE[invoice.status]}`}
+                        >
                           {invoice.status}
                         </span>
                       </td>

--- a/frontend/app/dashboard/billing/page.tsx
+++ b/frontend/app/dashboard/billing/page.tsx
@@ -1,13 +1,233 @@
 "use client";
 
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, CreditCard, Receipt } from "lucide-react";
+import { useAuth } from "@/app/context/AuthContext";
 import InvoicesView from "./invoices";
+import {
+  fetchBillingInvoices,
+  fetchSubscription,
+  type BillingSource,
+  type Invoice,
+  type Subscription,
+  type SubscriptionStatus,
+} from "@/services/billingService";
+import { invoiceTotal } from "@/services/billingMock";
+
+function formatUsd(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+const SUBSCRIPTION_LABEL: Record<SubscriptionStatus, string> = {
+  active: "Active",
+  trialing: "Trial",
+  past_due: "Past due",
+  canceled: "Canceled",
+};
+
+const SUBSCRIPTION_STYLE: Record<SubscriptionStatus, string> = {
+  active:
+    "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border border-green-200 dark:border-green-800",
+  trialing:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-200 dark:border-blue-800",
+  past_due:
+    "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border border-red-200 dark:border-red-800",
+  canceled:
+    "bg-gray-100 text-gray-700 dark:bg-white/10 dark:text-gray-300 border border-gray-200 dark:border-white/10",
+};
+
+function SummaryTile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-bold text-gray-900 dark:text-white">{value}</p>
+      {hint && <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
+    </div>
+  );
+}
+
+function SubscriptionCard({ subscription }: { subscription: Subscription }) {
+  const usage =
+    subscription.verificationsIncluded === null
+      ? "Unlimited"
+      : `${subscription.verificationsUsed} of ${subscription.verificationsIncluded}`;
+
+  return (
+    <section
+      className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-darkblue p-6 shadow-sm"
+      aria-labelledby="subscription-heading"
+      data-testid="subscription-card"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-primary/20 bg-primary/10">
+            <CreditCard className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h2 id="subscription-heading" className="text-lg font-bold text-gray-900 dark:text-white">
+              {subscription.planName} plan
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {formatUsd(subscription.priceUsd)} per {subscription.interval}
+            </p>
+          </div>
+        </div>
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${SUBSCRIPTION_STYLE[subscription.status]}`}
+          data-testid="subscription-status"
+        >
+          {SUBSCRIPTION_LABEL[subscription.status]}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <SummaryTile
+          label={subscription.cancelAtPeriodEnd ? "Access until" : "Renews on"}
+          value={formatDate(subscription.currentPeriodEnd)}
+          hint={subscription.cancelAtPeriodEnd ? "Auto-renewal is off" : undefined}
+        />
+        <SummaryTile label="Verifications used" value={usage} hint="This billing period" />
+        <SummaryTile
+          label="Next charge"
+          value={subscription.cancelAtPeriodEnd ? "None" : formatUsd(subscription.priceUsd)}
+          hint={subscription.cancelAtPeriodEnd ? "Plan ends this period" : "Billed automatically"}
+        />
+      </div>
+
+      <Link
+        href="/pricing"
+        className="mt-5 inline-flex items-center rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90"
+      >
+        Change plan
+      </Link>
+    </section>
+  );
+}
+
+function SampleDataNotice() {
+  return (
+    <div
+      className="flex items-start gap-2 rounded-xl border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
+      role="status"
+      data-testid="sample-data-notice"
+    >
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <p>
+        The billing API is unavailable, so sample figures are shown. Reconnect to see your live
+        subscription and invoices.
+      </p>
+    </div>
+  );
+}
 
 export default function BillingPage() {
+  const { user } = useAuth();
+  const email = user?.email ?? "user@stellarproof.com";
+
+  const [subscription, setSubscription] = useState<Subscription | null>(null);
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [source, setSource] = useState<BillingSource>("api");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+
+    Promise.all([
+      fetchSubscription({ email, signal: controller.signal }),
+      fetchBillingInvoices({ email, signal: controller.signal }),
+    ])
+      .then(([subscriptionResult, invoicesResult]) => {
+        if (cancelled) return;
+        setSubscription(subscriptionResult.data);
+        setInvoices(invoicesResult.data);
+        // Only claim the data is live when both halves came from the API.
+        setSource(
+          subscriptionResult.source === "api" && invoicesResult.source === "api"
+            ? "api"
+            : "sample",
+        );
+        setError(null);
+      })
+      .catch((err) => {
+        if (cancelled || (err instanceof DOMException && err.name === "AbortError")) return;
+        console.error("Failed to load billing data:", err);
+        setError("We could not load your billing details. Please try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [email, reloadToken]);
+
+  const handleRetry = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
+    setReloadToken((token) => token + 1);
+  }, []);
+
+  const outstanding = invoices
+    .filter((invoice) => invoice.status !== "paid")
+    .reduce((sum, invoice) => sum + invoiceTotal(invoice), 0);
+
   return (
     <main className="min-h-screen bg-white dark:bg-darkblue-dark px-4 py-10 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-5xl">
-        <InvoicesView />
+      <div className="mx-auto max-w-5xl space-y-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-primary/20 bg-primary/10">
+            <Receipt className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Billing</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Your plan, usage and invoice history for {email}.
+            </p>
+          </div>
+        </div>
+
+        {!isLoading && !error && source === "sample" && <SampleDataNotice />}
+
+        {isLoading ? (
+          <div
+            className="h-44 animate-pulse rounded-2xl border border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-white/5"
+            data-testid="subscription-skeleton"
+          />
+        ) : (
+          subscription && <SubscriptionCard subscription={subscription} />
+        )}
+
+        {!isLoading && !error && outstanding > 0 && (
+          <p className="text-sm font-medium text-gray-700 dark:text-gray-300" data-testid="outstanding-total">
+            Outstanding balance: {formatUsd(outstanding)}
+          </p>
+        )}
+
+        <h2 className="pt-2 text-lg font-bold text-gray-900 dark:text-white">Invoices</h2>
+
+        <InvoicesView
+          invoices={invoices}
+          isLoading={isLoading}
+          error={error}
+          onRetry={handleRetry}
+          showHeader={false}
+        />
       </div>
     </main>
   );

--- a/frontend/services/__tests__/billingService.test.ts
+++ b/frontend/services/__tests__/billingService.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for the live billing service: envelope handling, wire-shape mapping
+ * and the sample-data fallback used while the billing endpoints are rolling
+ * out.
+ */
+
+import {
+  INVOICES_ENDPOINT,
+  SUBSCRIPTION_ENDPOINT,
+  fetchBillingInvoices,
+  fetchSubscription,
+  mapApiInvoice,
+  mapApiSubscription,
+} from "../billingService";
+
+const ORIGINAL_FETCH = global.fetch;
+
+function mockJsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+beforeEach(() => {
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  global.fetch = jest.fn() as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  global.fetch = ORIGINAL_FETCH;
+  window.localStorage.clear();
+});
+
+describe("fetchSubscription", () => {
+  it("requests the subscription endpoint and maps the payload", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({
+        success: true,
+        data: {
+          planName: "Personal",
+          status: "TRIALING",
+          priceUsd: 9,
+          interval: "month",
+          currentPeriodEnd: "2026-09-01T00:00:00.000Z",
+          verificationsUsed: 4,
+          verificationsIncluded: 100,
+        },
+      }),
+    );
+
+    const result = await fetchSubscription({ email: "buyer@example.com" });
+
+    expect(global.fetch).toHaveBeenCalledWith(SUBSCRIPTION_ENDPOINT, expect.anything());
+    expect(result.source).toBe("api");
+    expect(result.data).toEqual({
+      planName: "Personal",
+      status: "trialing",
+      priceUsd: 9,
+      interval: "month",
+      currentPeriodEnd: "2026-09-01T00:00:00.000Z",
+      cancelAtPeriodEnd: false,
+      verificationsUsed: 4,
+      verificationsIncluded: 100,
+    });
+  });
+
+  it("sends the stored auth token as a bearer header", async () => {
+    window.localStorage.setItem(
+      "stellarproof_auth",
+      JSON.stringify({ isAuthenticated: true, token: "jwt-123" }),
+    );
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({ success: true, data: { planName: "Pro" } }),
+    );
+
+    await fetchSubscription();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      SUBSCRIPTION_ENDPOINT,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer jwt-123" }),
+      }),
+    );
+  });
+
+  it("falls back to sample data when the API is unreachable", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const result = await fetchSubscription({ email: "buyer@example.com" });
+
+    expect(result.source).toBe("sample");
+    expect(result.data.planName).toBe("Pro");
+  });
+
+  it("falls back to sample data when the endpoint is missing", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({ success: false, error: "Not found" }, false, 404),
+    );
+
+    const result = await fetchSubscription();
+
+    expect(result.source).toBe("sample");
+  });
+
+  it("propagates aborts instead of falling back", async () => {
+    (global.fetch as jest.Mock).mockRejectedValue(
+      new DOMException("The user aborted a request.", "AbortError"),
+    );
+
+    await expect(fetchSubscription()).rejects.toThrow(/aborted/i);
+  });
+});
+
+describe("fetchBillingInvoices", () => {
+  it("maps the API payload and sorts newest first", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({
+        success: true,
+        data: {
+          invoices: [
+            {
+              invoiceNumber: "INV-2026-0001",
+              issuedAt: "2026-01-05T00:00:00.000Z",
+              dueAt: "2026-02-04T00:00:00.000Z",
+              status: "PAID",
+              billedToName: "Test User",
+              lineItems: [{ description: "Pro plan", quantity: 1, unitPrice: 49 }],
+            },
+            {
+              invoiceNumber: "INV-2026-0002",
+              issuedAt: "2026-02-05T00:00:00.000Z",
+              dueAt: "2026-03-07T00:00:00.000Z",
+              status: "overdue",
+              amountUsd: 49,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await fetchBillingInvoices({ email: "buyer@example.com" });
+
+    expect(global.fetch).toHaveBeenCalledWith(INVOICES_ENDPOINT, expect.anything());
+    expect(result.source).toBe("api");
+    expect(result.data.map((invoice) => invoice.id)).toEqual([
+      "INV-2026-0002",
+      "INV-2026-0001",
+    ]);
+    // A total-only invoice is expanded into a single line item.
+    expect(result.data[0].lineItems).toEqual([
+      { description: "Subscription charge", quantity: 1, unitPrice: 49 },
+    ]);
+    expect(result.data[0].billedToEmail).toBe("buyer@example.com");
+  });
+
+  it("accepts a bare array payload", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({ success: true, data: [{ invoiceNumber: "INV-1" }] }),
+    );
+
+    const result = await fetchBillingInvoices();
+
+    expect(result.source).toBe("api");
+    expect(result.data).toHaveLength(1);
+  });
+
+  it("falls back to sample invoices on an unexpected shape", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(
+      mockJsonResponse({ success: true, data: { invoices: "nope" } }),
+    );
+
+    const result = await fetchBillingInvoices({ email: "buyer@example.com" });
+
+    expect(result.source).toBe("sample");
+    expect(result.data.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to sample invoices when the response is not JSON", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    } as unknown as Response);
+
+    const result = await fetchBillingInvoices();
+
+    expect(result.source).toBe("sample");
+  });
+});
+
+describe("wire-shape mapping", () => {
+  it("defaults missing invoice fields", () => {
+    const invoice = mapApiInvoice({}, "fallback@example.com");
+
+    expect(invoice.id).toBe("UNKNOWN");
+    expect(invoice.status).toBe("pending");
+    expect(invoice.currency).toBe("USD");
+    expect(invoice.billedToEmail).toBe("fallback@example.com");
+    expect(invoice.lineItems).toEqual([]);
+  });
+
+  it("normalises unknown statuses and intervals", () => {
+    const subscription = mapApiSubscription({
+      plan: "Team",
+      status: "something-else",
+      interval: "week",
+      cancelAtPeriodEnd: true,
+    });
+
+    expect(subscription.planName).toBe("Team");
+    expect(subscription.status).toBe("active");
+    expect(subscription.interval).toBe("month");
+    expect(subscription.cancelAtPeriodEnd).toBe(true);
+    expect(subscription.verificationsIncluded).toBeNull();
+  });
+
+  it("keeps past_due when the API hyphenates it", () => {
+    expect(mapApiSubscription({ status: "past-due" }).status).toBe("past_due");
+  });
+});

--- a/frontend/services/billingMock.ts
+++ b/frontend/services/billingMock.ts
@@ -18,12 +18,52 @@ export interface Invoice {
   currency: "USD";
 }
 
+export type SubscriptionStatus = "active" | "trialing" | "past_due" | "canceled";
+
+export interface Subscription {
+  planName: string;
+  status: SubscriptionStatus;
+  /** Recurring price in USD for one billing interval. */
+  priceUsd: number;
+  interval: "month" | "year";
+  /** End of the current billing period, i.e. the next renewal date. */
+  currentPeriodEnd: string;
+  /** True when the plan has been cancelled but is still running out its term. */
+  cancelAtPeriodEnd: boolean;
+  verificationsUsed: number;
+  /** Verifications included in the plan; null means unlimited. */
+  verificationsIncluded: number | null;
+}
+
 export function invoiceTotal(invoice: Invoice): number {
   return invoice.lineItems.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
 }
 
 function daysAgo(days: number): string {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * Fetches the current subscription for a user. Sample counterpart to
+ * `billingService.fetchSubscription`, used until the billing endpoints are
+ * deployed.
+ */
+export async function fetchSubscription(email: string): Promise<Subscription> {
+  void email;
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        planName: "Pro",
+        status: "active",
+        priceUsd: 49,
+        interval: "month",
+        currentPeriodEnd: daysAgo(-28),
+        cancelAtPeriodEnd: false,
+        verificationsUsed: 128,
+        verificationsIncluded: null,
+      });
+    }, 400);
+  });
 }
 
 /**

--- a/frontend/services/billingService.ts
+++ b/frontend/services/billingService.ts
@@ -1,0 +1,309 @@
+/**
+ * Live billing service.
+ *
+ * Talks to the StellarProof backend REST API for the signed-in user's
+ * subscription (`GET /api/v1/users/me/subscription`) and billing history
+ * (`GET /api/v1/users/me/invoices`), following the same envelope and error
+ * conventions as the certificate search service.
+ *
+ * The billing endpoints are not deployed on every environment yet, so both
+ * loaders degrade gracefully: when the API is unreachable or does not expose
+ * the route, they resolve with the mock payload from `billingMock` and mark
+ * the result `source: "sample"`, letting the dashboard render something
+ * useful while telling the user the figures are not live.
+ */
+
+import {
+  fetchInvoices as fetchSampleInvoices,
+  fetchSubscription as fetchSampleSubscription,
+  type Invoice,
+  type InvoiceLineItem,
+  type InvoiceStatus,
+  type Subscription,
+  type SubscriptionStatus,
+} from "./billingMock";
+
+export type { Invoice, InvoiceLineItem, InvoiceStatus, Subscription, SubscriptionStatus };
+
+/* -------------------------------------------------------------------------- */
+/*                              Configuration                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Base URL of the StellarProof backend. Configure with `NEXT_PUBLIC_API_URL`
+ * (see frontend/.env.example). Defaults to the local development backend.
+ */
+export const API_BASE_URL: string =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+const API_ROOT = `${API_BASE_URL.replace(/\/$/, "")}/api/v1`;
+
+export const SUBSCRIPTION_ENDPOINT = `${API_ROOT}/users/me/subscription`;
+export const INVOICES_ENDPOINT = `${API_ROOT}/users/me/invoices`;
+
+/** Where the rendered data came from, so the UI can flag non-live figures. */
+export type BillingSource = "api" | "sample";
+
+export interface BillingResult<T> {
+  data: T;
+  source: BillingSource;
+}
+
+export interface FetchBillingOptions {
+  /** AbortSignal so stale/unmounted requests can be cancelled. */
+  signal?: AbortSignal;
+  /** Email used for the sample fallback payload. */
+  email?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                         API response wire shapes                           */
+/* -------------------------------------------------------------------------- */
+
+interface ApiEnvelope<T> {
+  success?: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+interface ApiLineItem {
+  description?: string;
+  quantity?: number;
+  unitPrice?: number;
+}
+
+interface ApiInvoice {
+  id?: string;
+  _id?: string;
+  invoiceNumber?: string;
+  issuedAt?: string;
+  createdAt?: string;
+  dueAt?: string;
+  dueDate?: string;
+  status?: string;
+  billedToName?: string;
+  billedToEmail?: string;
+  currency?: string;
+  lineItems?: ApiLineItem[];
+  /** Some backends only send a total; it is expanded into a single line item. */
+  amountUsd?: number;
+}
+
+interface ApiInvoiceList {
+  invoices?: ApiInvoice[];
+}
+
+interface ApiSubscription {
+  planName?: string;
+  plan?: string;
+  status?: string;
+  priceUsd?: number;
+  amountUsd?: number;
+  interval?: string;
+  currentPeriodEnd?: string;
+  renewsAt?: string;
+  cancelAtPeriodEnd?: boolean;
+  verificationsUsed?: number;
+  verificationsIncluded?: number | null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                 Mapping                                    */
+/* -------------------------------------------------------------------------- */
+
+const INVOICE_STATUSES: InvoiceStatus[] = ["paid", "pending", "overdue"];
+const SUBSCRIPTION_STATUSES: SubscriptionStatus[] = [
+  "active",
+  "trialing",
+  "past_due",
+  "canceled",
+];
+
+function toInvoiceStatus(value?: string): InvoiceStatus {
+  const status = value?.toLowerCase() as InvoiceStatus | undefined;
+  return status && INVOICE_STATUSES.includes(status) ? status : "pending";
+}
+
+function toSubscriptionStatus(value?: string): SubscriptionStatus {
+  const status = value?.toLowerCase().replace(/-/g, "_") as SubscriptionStatus | undefined;
+  return status && SUBSCRIPTION_STATUSES.includes(status) ? status : "active";
+}
+
+/** Normalise an ISO-ish timestamp, falling back to the epoch when unusable. */
+function toIso(value?: string): string {
+  if (!value) return new Date(0).toISOString();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function mapApiInvoice(invoice: ApiInvoice, fallbackEmail: string): Invoice {
+  const lineItems: InvoiceLineItem[] = Array.isArray(invoice.lineItems)
+    ? invoice.lineItems.map((item) => ({
+        description: item.description?.trim() || "Subscription charge",
+        quantity: toNumber(item.quantity, 1),
+        unitPrice: toNumber(item.unitPrice),
+      }))
+    : [];
+
+  // Backends that only report a total still need one row so the table and the
+  // generated PDF have something to show.
+  if (lineItems.length === 0 && invoice.amountUsd !== undefined) {
+    lineItems.push({
+      description: "Subscription charge",
+      quantity: 1,
+      unitPrice: toNumber(invoice.amountUsd),
+    });
+  }
+
+  return {
+    id: invoice.invoiceNumber ?? invoice.id ?? invoice._id ?? "UNKNOWN",
+    issuedAt: toIso(invoice.issuedAt ?? invoice.createdAt),
+    dueAt: toIso(invoice.dueAt ?? invoice.dueDate ?? invoice.issuedAt ?? invoice.createdAt),
+    status: toInvoiceStatus(invoice.status),
+    billedToName: invoice.billedToName ?? "StellarProof User",
+    billedToEmail: invoice.billedToEmail ?? fallbackEmail,
+    currency: "USD",
+    lineItems,
+  };
+}
+
+export function mapApiSubscription(subscription: ApiSubscription): Subscription {
+  return {
+    planName: subscription.planName ?? subscription.plan ?? "Free",
+    status: toSubscriptionStatus(subscription.status),
+    priceUsd: toNumber(subscription.priceUsd ?? subscription.amountUsd),
+    interval: subscription.interval === "year" ? "year" : "month",
+    currentPeriodEnd: toIso(subscription.currentPeriodEnd ?? subscription.renewsAt),
+    cancelAtPeriodEnd: subscription.cancelAtPeriodEnd === true,
+    verificationsUsed: toNumber(subscription.verificationsUsed),
+    verificationsIncluded:
+      typeof subscription.verificationsIncluded === "number"
+        ? subscription.verificationsIncluded
+        : null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Fetch plumbing                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Bearer token persisted by the auth context, when the session carries one.
+ * The billing endpoints are authenticated, so it is forwarded whenever it is
+ * available; unauthenticated calls simply come back as 401 and fall back to
+ * the sample payload.
+ */
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem("stellarproof_auth");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { token?: unknown };
+    return typeof parsed.token === "string" && parsed.token ? parsed.token : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Raised when the request reached the API but the API refused it. */
+class BillingApiError extends Error {}
+
+async function requestJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const token = getAuthToken();
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      signal,
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      // Propagate cancellations untouched so callers can ignore them.
+      throw err;
+    }
+    throw new BillingApiError("Unable to reach the StellarProof billing API.");
+  }
+
+  let body: ApiEnvelope<T> | undefined;
+  try {
+    body = (await response.json()) as ApiEnvelope<T>;
+  } catch {
+    // Non-JSON body (proxy error page, HTML gateway response, …).
+    body = undefined;
+  }
+
+  if (!response.ok) {
+    throw new BillingApiError(
+      body?.error ?? body?.message ?? `Billing request failed with status ${response.status}.`,
+    );
+  }
+
+  if (!body || body.success === false || body.data === undefined) {
+    throw new BillingApiError(
+      body?.error ?? body?.message ?? "Billing request failed. Please try again.",
+    );
+  }
+
+  return body.data;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                Public API                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Loads the signed-in user's current subscription. Falls back to the sample
+ * subscription when the billing API is unavailable.
+ */
+export async function fetchSubscription(
+  options: FetchBillingOptions = {},
+): Promise<BillingResult<Subscription>> {
+  const { signal, email = "user@stellarproof.com" } = options;
+
+  try {
+    const payload = await requestJson<ApiSubscription>(SUBSCRIPTION_ENDPOINT, signal);
+    return { data: mapApiSubscription(payload), source: "api" };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    console.warn("Falling back to sample subscription:", err);
+    return { data: await fetchSampleSubscription(email), source: "sample" };
+  }
+}
+
+/**
+ * Loads the signed-in user's billing history, newest invoice first. Falls
+ * back to the sample invoices when the billing API is unavailable.
+ */
+export async function fetchBillingInvoices(
+  options: FetchBillingOptions = {},
+): Promise<BillingResult<Invoice[]>> {
+  const { signal, email = "user@stellarproof.com" } = options;
+
+  try {
+    const payload = await requestJson<ApiInvoice[] | ApiInvoiceList>(INVOICES_ENDPOINT, signal);
+    const raw = Array.isArray(payload) ? payload : payload.invoices;
+    if (!Array.isArray(raw)) {
+      throw new BillingApiError("Unexpected response shape from the invoices API.");
+    }
+
+    const invoices = raw
+      .map((invoice) => mapApiInvoice(invoice, email))
+      .sort((a, b) => new Date(b.issuedAt).getTime() - new Date(a.issuedAt).getTime());
+
+    return { data: invoices, source: "api" };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") throw err;
+    console.warn("Falling back to sample invoices:", err);
+    return { data: await fetchSampleInvoices(email), source: "sample" };
+  }
+}


### PR DESCRIPTION
Closes #416

## Goal

Unit-test the billing dashboard and the invoice list against mocked API responses, so table rendering and data population are covered in CI.

## What changed

Adds `app/dashboard/billing/__tests__/billing.test.tsx` (11 cases). `services/billingService` is mocked, so the suite is a pure rendering test with no network involved. `@react-pdf/renderer`, the blob download helper and the auth/toast contexts are mocked too, keeping the tests fast and deterministic.

**Data loading**
- the page requests the signed-in user's subscription and invoices
- skeletons render until both requests resolve

**Subscription card**
- plan name, price per interval, status badge, renewal date and usage are populated from the mocked payload
- the alternate wording when auto-renewal is off ("Access until", "Auto-renewal is off", next charge "None")

**Invoice table**
- rows are populated in the order returned by the API
- totals are summed across line items (`1 x $9.00 + 2 x $1.50` renders `$12.00`)
- the multi-item summary renders (`Personal plan +1 more`)
- every row exposes a Download PDF action

**Derived and degraded states**
- outstanding balance across unpaid invoices, and its absence when everything is paid
- the empty state for an account with no invoices
- the sample-data notice appears only when part of the response is not live
- the error state reloads the data when the user retries

## Result

```
Tests: 11 passed, 11 total
```

Together with the existing `invoices.test.tsx` and the new `billingService.test.ts`, the billing area runs 33 passing tests.

`pnpm --filter web run lint` and `pnpm --filter web run build` both pass.

## Notes for review

- Built on top of #414 (and #413 beneath it), since these tests exercise the dashboard those PRs introduce. Merging them first reduces this diff to the single new test file.
- Assertions are scoped with `within(...)` per region so a future layout change does not produce false matches elsewhere on the page.
