### PR TITLE
feat(verification): integrate Zod validation and React Hook Form resolver for manifest inputs

### DIFF
--- a/frontend/features/verification/components/ManifestGeneratorForm.tsx
+++ b/frontend/features/verification/components/ManifestGeneratorForm.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { manifestSchema, ManifestFormData } from '../schemas/manifest.schema';
+
+export const ManifestGeneratorForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ManifestFormData>({
+    resolver: zodResolver(manifestSchema),
+  });
+
+  const onSubmit = (data: ManifestFormData) => {
+    console.log('Validated Manifest Data:', data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+      <div>
+        <label>Title</label>
+        <input {...register('title')} />
+        {errors.title && <span className="text-red-500 text-sm">{errors.title.message}</span>}
+      </div>
+
+      <div>
+        <label>Description</label>
+        <textarea {...register('description')} />
+        {errors.description && <span className="text-red-500 text-sm">{errors.description.message}</span>}
+      </div>
+
+      <div>
+        <label>Version</label>
+        <input {...register('version')} placeholder="1.0.0" />
+        {errors.version && <span className="text-red-500 text-sm">{errors.version.message}</span>}
+      </div>
+
+      <div>
+        <label>Author</label>
+        <input {...register('author')} />
+        {errors.author && <span className="text-red-500 text-sm">{errors.author.message}</span>}
+      </div>
+
+      <button type="submit">Generate Manifest</button>
+    </form>
+  );
+};

--- a/frontend/features/verification/schemas/manifest.schema.ts
+++ b/frontend/features/verification/schemas/manifest.schema.ts
@@ -1,0 +1,23 @@
+// frontend/features/verification/schemas/manifest.schema.ts
+
+import { z } from 'zod';
+
+export const manifestSchema = z.object({
+  title: z
+    .string()
+    .min(1, { message: 'Title is required' })
+    .max(100, { message: 'Title must be 100 characters or less' }),
+  description: z
+    .string()
+    .min(1, { message: 'Description is required' })
+    .max(500, { message: 'Description must be 500 characters or less' }),
+  version: z
+    .string()
+    .min(1, { message: 'Version is required' })
+    .regex(/^\d+\.\d+\.\d+$/, { message: 'Version must follow semantic versioning (e.g., 1.0.0)' }),
+  author: z
+    .string()
+    .min(1, { message: 'Author name or address is required' }),
+});
+
+export type ManifestFormData = z.infer<typeof manifestSchema>;


### PR DESCRIPTION

Summary
This PR resolves #428 by implementing a robust Zod validation schema for the Manifest Generator inputs and integrating it with React Hook Form via the @hookform/resolvers/zod resolver.

Changes Proposed

    Created manifest.schema.ts defining strict validation rules for title, description, version (semantic versioning check), and author.

    Configured React Hook Form to use the Zod resolver, ensuring validation errors are cleanly intercepted before submission and rendered directly beneath the corresponding fields.

Acceptance Criteria Checklist

    [x] Create a Zod schema for the manifest data.

    [x] Integrate with React Hook Form resolver.

    [x] Validation errors display correctly under fields.

Closes #428